### PR TITLE
CTFD-35 - Create target management dialog

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,14 +1,34 @@
 <div class="app-root flex flex-col h-screen">
-  <spartan-menubar></spartan-menubar>
+  <!-- Menubar -->
+  <spartan-menubar
+    (openTargetManagerEvent)="openTargetManager($event)"
+  ></spartan-menubar>
 
   <div class="app-layout flex-1 flex overflow-hidden">
     <ctf-chat-sidebar
       class="flex-none border-r border-border transition-[width] duration-300 ease-in-out"
     ></ctf-chat-sidebar>
 
-    <main class="app-main flex-1 overflow-auto">
-      <!-- Routed pages will render here -->
+    <main class="app-main flex-1 overflow-auto relative">
       <router-outlet></router-outlet>
     </main>
+  </div>
+
+  <!-- Modal Target Manager -->
+  <div 
+    *ngIf="targetManagerVisible" 
+    class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+    (click)="closeTargetManager()"
+  >
+    <div 
+      class="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-auto m-4"
+      (click)="$event.stopPropagation()"
+    >
+      <app-target-manager 
+        #targetManager
+        [mode]="targetManagerMode"
+        (closeEvent)="closeTargetManager()"
+      ></app-target-manager>
+    </div>
   </div>
 </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,14 +1,41 @@
-import { Component, signal } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { CommonModule } from '@angular/common';
 import { Menubar } from '../ui/menubar/menubar';
 import { ChatSidebar } from '../ui/sidebar/chat-sidebar';
+import { TargetManagerComponent } from '../ui/target-manager/target-manager.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, Menubar, ChatSidebar],
+  standalone: true,
+  imports: [CommonModule, RouterOutlet, Menubar, ChatSidebar, TargetManagerComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css'],
 })
 export class App {
   protected readonly title = signal('CTFDeck-app');
+  
+  targetManagerVisible = false;
+  targetManagerMode: 'view' | 'add' | 'delete' = 'view';
+  
+  @ViewChild('targetManager', { static: false }) targetManager?: TargetManagerComponent;
+
+  openTargetManager(mode: 'view' | 'add' | 'delete') {
+    this.targetManagerMode = mode;
+    this.targetManagerVisible = true;
+    
+    setTimeout(() => {
+      if (this.targetManager) {
+        this.targetManager.open(this.targetManagerMode);
+      }
+    }, 0);
+  }
+
+  closeTargetManager() {
+    this.targetManagerVisible = false;
+  }
+
+  saveTargets() {
+    console.log('Targets already saved in cookies');
+  }
 }

--- a/src/app/core/services/target.service.ts
+++ b/src/app/core/services/target.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+export interface Target {
+  id: string;
+  name: string;
+  host: string;
+  port?: number;
+  description?: string;
+  createdAt: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TargetService {
+  private readonly STORAGE_KEY = 'ctfdeck_targets';
+
+  getTargets(): Target[] {
+    const stored = localStorage.getItem(this.STORAGE_KEY);
+    if (!stored) return [];
+    
+    try {
+      return JSON.parse(stored);
+    } catch (error) {
+      console.error('Error parsing targets:', error);
+      return [];
+    }
+  }
+}

--- a/src/ui/menubar/menubar.html
+++ b/src/ui/menubar/menubar.html
@@ -19,10 +19,10 @@
   <ng-template #target>
     <hlm-menu variant="menubar" class="w-56">
       <hlm-menu-group>
-        <button hlmMenuItem>Configuration</button>
-        <button hlmMenuItem>Ajout d’une cible</button>
-        <button hlmMenuItem>Retrait d’une cible</button>
-        <button hlmMenuItem>Sauvegarde d’une cible</button>
+        <button hlmMenuItem (click)="openTargetManager('view')">Configuration</button>
+        <button hlmMenuItem (click)="openTargetManager('add')">Ajout d'une cible</button>
+        <button hlmMenuItem (click)="openTargetManager('delete')">Retrait d'une cible</button>
+        <button hlmMenuItem (click)="saveTargets()">Sauvegarde d'une cible</button>
       </hlm-menu-group>
     </hlm-menu>
   </ng-template>
@@ -40,7 +40,6 @@
   <ng-template #utils>
     <hlm-menu variant="menubar" class="w-64">
       <hlm-menu-group>
-        <!-- Single Tools entry that opens a sub-menu like Edit did before -->
         <button hlmMenuItem align="start" side="right" [brnMenuTriggerFor]="tools_sub">
           Tools
           <hlm-menu-item-sub-indicator />

--- a/src/ui/menubar/menubar.ts
+++ b/src/ui/menubar/menubar.ts
@@ -1,24 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, Output, EventEmitter } from '@angular/core';
 import { Router } from '@angular/router';
 import { BrnMenuTrigger } from '@spartan-ng/brain/menu';
-
 import {
   HlmMenu,
   HlmMenuBar,
   HlmMenuBarItem,
   HlmMenuGroup,
   HlmMenuItem,
-  HlmMenuItemCheck,
-  HlmMenuItemCheckbox,
-  HlmMenuItemRadio,
-  HlmMenuItemRadioIndicator,
   HlmMenuItemSubIndicator,
   HlmMenuSeparator,
-  HlmMenuShortcut,
   HlmSubMenu,
 } from '@ctfdeck/helm/menu';
-import { HlmButtonImports } from '@ctfdeck/helm/button';
-
 import { ThemeToggle } from './theme-toggle';
 
 @Component({
@@ -41,6 +33,8 @@ import { ThemeToggle } from './theme-toggle';
 })
 export class Menubar {
   constructor(private router: Router) {}
+  
+  @Output() openTargetManagerEvent = new EventEmitter<'view' | 'add' | 'delete'>();
 
   navigate(path: string) {
     this.router.navigate([path]);
@@ -48,5 +42,13 @@ export class Menubar {
 
   openExternal(url: string) {
     window.open(url, '_blank', 'noopener');
+  }
+
+  openTargetManager(mode: 'view' | 'add' | 'delete') {
+    this.openTargetManagerEvent.emit(mode);
+  }
+
+  saveTargets() {
+    console.log('Targets already saved in cookies');
   }
 }

--- a/src/ui/target-manager/target-manager.component.ts
+++ b/src/ui/target-manager/target-manager.component.ts
@@ -1,0 +1,72 @@
+import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TargetService, Target } from '../../app/core/services/target.service';
+
+@Component({
+  selector: 'app-target-manager',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="target-manager p-6">
+      <!-- Header -->
+      <div class="flex justify-between items-center mb-6 border-b pb-4">
+        <h2 class="text-2xl font-bold">
+          {{ mode === 'view' ? '📋 Configuration des cibles' : 
+             mode === 'add' ? '➕ Ajouter une cible' : 
+             '🗑️ Supprimer des cibles' }}
+        </h2>
+        <button 
+          (click)="close()" 
+          class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-2xl font-bold"
+          aria-label="Fermer"
+        >
+          ×
+        </button>
+      </div>
+      
+      <!-- Contenu temporaire -->
+      <div class="min-h-[300px] flex items-center justify-center">
+        <div class="text-center">
+          <p class="text-lg text-gray-600 dark:text-gray-400 mb-4">
+            Modal Target Manager créée avec succès !
+          </p>
+          <p class="text-sm text-gray-500">
+            Mode actuel : <span class="font-semibold">{{ mode }}</span>
+          </p>
+          <p class="text-xs text-gray-400 mt-4">
+            Les fonctionnalités d'ajout, édition et suppression seront implémentées dans les prochaines issues.
+          </p>
+        </div>
+      </div>
+      
+      <!-- Footer -->
+      <div class="flex justify-end gap-3 mt-6 pt-4 border-t">
+        <button 
+          (click)="close()" 
+          class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400 transition"
+        >
+          Fermer
+        </button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: block;
+    }
+  `]
+})
+export class TargetManagerComponent {
+  @Input() mode: 'view' | 'add' | 'delete' = 'view';
+  @Output() closeEvent = new EventEmitter<void>();
+  
+  constructor(private targetService: TargetService) {}
+  
+  open(mode: 'view' | 'add' | 'delete') {
+    this.mode = mode;
+  }
+  
+  close() {
+    this.closeEvent.emit();
+  }
+}


### PR DESCRIPTION
This pull request introduces a modal-based Target Manager feature to the application, allowing users to view, add, or delete targets via a dedicated UI. The implementation includes a new `TargetService` for managing targets, updates to the menubar to trigger the modal in different modes, and the creation of a `TargetManagerComponent` as a modal dialog. The changes also refactor event handling between the menubar and the app root for better separation of concerns.

**Target Manager Feature Implementation:**

* Added a new `TargetManagerComponent` modal with support for 'view', 'add', and 'delete' modes, including event handling for opening and closing the modal. The modal currently displays placeholder content and will be extended in future issues.
* Introduced `TargetService` for managing targets in local storage, with a `Target` interface and a method to retrieve stored targets.

**Menubar and App Integration:**

* Updated the menubar to emit events (`openTargetManagerEvent`) for opening the Target Manager in different modes and added a stub for saving targets. [[1]](diffhunk://#diff-5981bddcb052ce07d3746acf51431ab5fdd94e069e956b919902c455e9f063a6L1-L21) [[2]](diffhunk://#diff-5981bddcb052ce07d3746acf51431ab5fdd94e069e956b919902c455e9f063a6R37-R53)
* Modified `app.html` and `app.ts` to handle modal visibility and mode, and to respond to menubar events by displaying the Target Manager modal. [[1]](diffhunk://#diff-b0ae384a2b28f3645c01d062ae3d1ae4ef8f5e6fc00c2292e2abc446cd6228d2L2-R33) [[2]](diffhunk://#diff-18f0b78b713daf3f4fc2d305926785508575bdc7f304363a64a3b3a2985b58beL1-R40)
* Updated menubar menu items to trigger the appropriate modal mode for configuration, adding, and deleting targets, and to call the save targets stub.

These changes lay the groundwork for target management functionality in the UI, with the modal and service structure ready for future enhancements.

(#35)