### PR TITLE
CTFD-39: Added Command run (for differents scripts execution

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,7 +44,7 @@
                   "type": "anyComponentStyle",
                   "maximumWarning": "4kB",
                   "maximumError": "8kB"
-                }
+                } 
               ],
               "outputHashing": "all"
             },

--- a/libs/ui/alert-dialog/src/index.ts
+++ b/libs/ui/alert-dialog/src/index.ts
@@ -1,0 +1,31 @@
+import { HlmAlertDialog } from './lib/hlm-alert-dialog';
+import { HlmAlertDialogActionButton } from './lib/hlm-alert-dialog-action-button';
+import { HlmAlertDialogCancelButton } from './lib/hlm-alert-dialog-cancel-button';
+import { HlmAlertDialogContent } from './lib/hlm-alert-dialog-content';
+import { HlmAlertDialogDescription } from './lib/hlm-alert-dialog-description';
+import { HlmAlertDialogFooter } from './lib/hlm-alert-dialog-footer';
+import { HlmAlertDialogHeader } from './lib/hlm-alert-dialog-header';
+import { HlmAlertDialogOverlay } from './lib/hlm-alert-dialog-overlay';
+import { HlmAlertDialogTitle } from './lib/hlm-alert-dialog-title';
+
+export * from './lib/hlm-alert-dialog';
+export * from './lib/hlm-alert-dialog-action-button';
+export * from './lib/hlm-alert-dialog-cancel-button';
+export * from './lib/hlm-alert-dialog-content';
+export * from './lib/hlm-alert-dialog-description';
+export * from './lib/hlm-alert-dialog-footer';
+export * from './lib/hlm-alert-dialog-header';
+export * from './lib/hlm-alert-dialog-overlay';
+export * from './lib/hlm-alert-dialog-title';
+
+export const HlmAlertDialogImports = [
+	HlmAlertDialogContent,
+	HlmAlertDialogDescription,
+	HlmAlertDialogFooter,
+	HlmAlertDialogHeader,
+	HlmAlertDialogOverlay,
+	HlmAlertDialogTitle,
+	HlmAlertDialogActionButton,
+	HlmAlertDialogCancelButton,
+	HlmAlertDialog,
+] as const;

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-action-button.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-action-button.ts
@@ -1,0 +1,8 @@
+import { Directive } from '@angular/core';
+import { HlmButton } from '@ctfdeck/helm/button';
+
+@Directive({
+	selector: 'button[hlmAlertDialogAction]',
+	hostDirectives: [{ directive: HlmButton, inputs: ['variant', 'size'] }],
+})
+export class HlmAlertDialogActionButton {}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-cancel-button.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-cancel-button.ts
@@ -1,0 +1,9 @@
+import { Directive } from '@angular/core';
+import { HlmButton, provideBrnButtonConfig } from '@ctfdeck/helm/button';
+
+@Directive({
+	selector: 'button[hlmAlertDialogCancel]',
+	providers: [provideBrnButtonConfig({ variant: 'outline' })],
+	hostDirectives: [{ directive: HlmButton, inputs: ['variant', 'size'] }],
+})
+export class HlmAlertDialogCancelButton {}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-content.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-content.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { injectExposesStateProvider } from '@spartan-ng/brain/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-alert-dialog-content',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+		'[attr.data-state]': 'state()',
+	},
+	template: `
+		<ng-content />
+	`,
+})
+export class HlmAlertDialogContent {
+	private readonly _stateProvider = injectExposesStateProvider({ optional: true, host: true });
+	public readonly state = this._stateProvider?.state ?? signal('closed');
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-description.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-description.ts
@@ -1,0 +1,16 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnAlertDialogDescription } from '@spartan-ng/brain/alert-dialog';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmAlertDialogDescription]',
+	hostDirectives: [BrnAlertDialogDescription],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmAlertDialogDescription {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-muted-foreground text-sm', this.userClass()));
+}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-footer.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-footer.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-alert-dialog-footer',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-content />
+	`,
+})
+export class HlmAlertDialogFooter {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', this.userClass()),
+	);
+}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-header.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-header.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-alert-dialog-header',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-content />
+	`,
+})
+export class HlmAlertDialogHeader {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('flex flex-col gap-2 text-center sm:text-left', this.userClass()),
+	);
+}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-overlay.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-overlay.ts
@@ -1,0 +1,26 @@
+import { Directive, computed, effect, input, untracked } from '@angular/core';
+import { injectCustomClassSettable } from '@spartan-ng/brain/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmAlertDialogOverlay],brn-alert-dialog-overlay[hlm]',
+})
+export class HlmAlertDialogOverlay {
+	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-black/50',
+			this.userClass(),
+		),
+	);
+
+	constructor() {
+		effect(() => {
+			const classValue = this._computedClass();
+			untracked(() => this._classSettable?.setClassToCustomElement(classValue));
+		});
+	}
+}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-title.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog-title.ts
@@ -1,0 +1,16 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnAlertDialogTitle } from '@spartan-ng/brain/alert-dialog';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmAlertDialogTitle]',
+	hostDirectives: [BrnAlertDialogTitle],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmAlertDialogTitle {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-lg font-semibold', this.userClass()));
+}

--- a/libs/ui/alert-dialog/src/lib/hlm-alert-dialog.ts
+++ b/libs/ui/alert-dialog/src/lib/hlm-alert-dialog.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import {
+	BRN_ALERT_DIALOG_DEFAULT_OPTIONS,
+	BrnAlertDialog,
+	BrnAlertDialogOverlay,
+} from '@spartan-ng/brain/alert-dialog';
+import { BrnDialog, provideBrnDialogDefaultOptions } from '@spartan-ng/brain/dialog';
+import { HlmAlertDialogOverlay } from './hlm-alert-dialog-overlay';
+
+@Component({
+	selector: 'hlm-alert-dialog',
+	exportAs: 'hlmAlertDialog',
+	imports: [BrnAlertDialogOverlay, HlmAlertDialogOverlay],
+	providers: [
+		{
+			provide: BrnDialog,
+			useExisting: forwardRef(() => HlmAlertDialog),
+		},
+		provideBrnDialogDefaultOptions({
+			...BRN_ALERT_DIALOG_DEFAULT_OPTIONS,
+		}),
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-alert-dialog-overlay hlm />
+		<ng-content />
+	`,
+})
+export class HlmAlertDialog extends BrnAlertDialog {}

--- a/libs/ui/dialog/src/index.ts
+++ b/libs/ui/dialog/src/index.ts
@@ -1,0 +1,29 @@
+import { HlmDialog } from './lib/hlm-dialog';
+import { HlmDialogClose } from './lib/hlm-dialog-close';
+import { HlmDialogContent } from './lib/hlm-dialog-content';
+import { HlmDialogDescription } from './lib/hlm-dialog-description';
+import { HlmDialogFooter } from './lib/hlm-dialog-footer';
+import { HlmDialogHeader } from './lib/hlm-dialog-header';
+import { HlmDialogOverlay } from './lib/hlm-dialog-overlay';
+import { HlmDialogTitle } from './lib/hlm-dialog-title';
+
+export * from './lib/hlm-dialog';
+export * from './lib/hlm-dialog-close';
+export * from './lib/hlm-dialog-content';
+export * from './lib/hlm-dialog-description';
+export * from './lib/hlm-dialog-footer';
+export * from './lib/hlm-dialog-header';
+export * from './lib/hlm-dialog-overlay';
+export * from './lib/hlm-dialog-title';
+export * from './lib/hlm-dialog.service';
+
+export const HlmDialogImports = [
+	HlmDialog,
+	HlmDialogClose,
+	HlmDialogContent,
+	HlmDialogDescription,
+	HlmDialogFooter,
+	HlmDialogHeader,
+	HlmDialogOverlay,
+	HlmDialogTitle,
+] as const;

--- a/libs/ui/dialog/src/lib/hlm-dialog-close.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-close.ts
@@ -1,0 +1,20 @@
+import { Directive, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmDialogClose],[brnDialogClose][hlm]',
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmDialogClose {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 flex items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none [&_ng-icon]:shrink-0',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-content.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-content.ts
@@ -1,0 +1,50 @@
+import { NgComponentOutlet } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideX } from '@ng-icons/lucide';
+import { BrnDialogClose, BrnDialogRef, injectBrnDialogContext } from '@spartan-ng/brain/dialog';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+import { HlmDialogClose } from './hlm-dialog-close';
+
+@Component({
+	selector: 'hlm-dialog-content',
+	imports: [NgComponentOutlet, BrnDialogClose, HlmDialogClose, NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideX })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+		'[attr.data-state]': 'state()',
+	},
+	template: `
+		@if (component) {
+			<ng-container [ngComponentOutlet]="component" />
+		} @else {
+			<ng-content />
+		}
+
+		<button brnDialogClose hlm>
+			<span class="sr-only">Close</span>
+			<ng-icon hlm size="sm" name="lucideX" />
+		</button>
+	`,
+})
+export class HlmDialogContent {
+	private readonly _dialogRef = inject(BrnDialogRef);
+	private readonly _dialogContext = injectBrnDialogContext({ optional: true });
+
+	public readonly state = computed(() => this._dialogRef?.state() ?? 'closed');
+
+	public readonly component = this._dialogContext?.$component;
+	private readonly _dynamicComponentClass = this._dialogContext?.$dynamicComponentClass;
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+			this.userClass(),
+			this._dynamicComponentClass,
+		),
+	);
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-description.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-description.ts
@@ -1,0 +1,16 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnDialogDescription } from '@spartan-ng/brain/dialog';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmDialogDescription]',
+	hostDirectives: [BrnDialogDescription],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmDialogDescription {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-muted-foreground text-sm', this.userClass()));
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-footer.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-footer.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-dialog-footer',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-content />
+	`,
+})
+export class HlmDialogFooter {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', this.userClass()),
+	);
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-header.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-header.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-dialog-header',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-content />
+	`,
+})
+export class HlmDialogHeader {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('flex flex-col gap-2 text-center sm:text-left', this.userClass()),
+	);
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-overlay.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-overlay.ts
@@ -1,0 +1,24 @@
+import { Directive, computed, effect, input, untracked } from '@angular/core';
+import { injectCustomClassSettable } from '@spartan-ng/brain/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+export const hlmDialogOverlayClass =
+	'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-black/50';
+
+@Directive({
+	selector: '[hlmDialogOverlay],brn-dialog-overlay[hlm]',
+})
+export class HlmDialogOverlay {
+	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm(hlmDialogOverlayClass, this.userClass()));
+
+	constructor() {
+		effect(() => {
+			const newClass = this._computedClass();
+			untracked(() => this._classSettable?.setClassToCustomElement(newClass));
+		});
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-title.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-title.ts
@@ -1,0 +1,16 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnDialogTitle } from '@spartan-ng/brain/dialog';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmDialogTitle]',
+	hostDirectives: [BrnDialogTitle],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmDialogTitle {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-lg leading-none font-semibold', this.userClass()));
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog.service.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog.service.ts
@@ -1,0 +1,38 @@
+import type { ComponentType } from '@angular/cdk/portal';
+import { Injectable, type TemplateRef, inject } from '@angular/core';
+import {
+	type BrnDialogOptions,
+	BrnDialogService,
+	DEFAULT_BRN_DIALOG_OPTIONS,
+	cssClassesToArray,
+} from '@spartan-ng/brain/dialog';
+import { HlmDialogContent } from './hlm-dialog-content';
+import { hlmDialogOverlayClass } from './hlm-dialog-overlay';
+
+export type HlmDialogOptions<DialogContext = unknown> = BrnDialogOptions & {
+	contentClass?: string;
+	context?: DialogContext;
+};
+
+@Injectable({
+	providedIn: 'root',
+})
+export class HlmDialogService {
+	private readonly _brnDialogService = inject(BrnDialogService);
+
+	public open(component: ComponentType<unknown> | TemplateRef<unknown>, options?: Partial<HlmDialogOptions>) {
+		const mergedOptions = {
+			...DEFAULT_BRN_DIALOG_OPTIONS,
+
+			...(options ?? {}),
+			backdropClass: cssClassesToArray(`${hlmDialogOverlayClass} ${options?.backdropClass ?? ''}`),
+			context: {
+				...(options?.context && typeof options.context === 'object' ? options.context : {}),
+				$component: component,
+				$dynamicComponentClass: options?.contentClass,
+			},
+		};
+
+		return this._brnDialogService.open(HlmDialogContent, undefined, mergedOptions.context, mergedOptions);
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import { BrnDialog, BrnDialogOverlay, provideBrnDialogDefaultOptions } from '@spartan-ng/brain/dialog';
+import { HlmDialogOverlay } from './hlm-dialog-overlay';
+
+@Component({
+	selector: 'hlm-dialog',
+	exportAs: 'hlmDialog',
+	imports: [BrnDialogOverlay, HlmDialogOverlay],
+	providers: [
+		{
+			provide: BrnDialog,
+			useExisting: forwardRef(() => HlmDialog),
+		},
+		provideBrnDialogDefaultOptions({
+			// add custom options here
+		}),
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-dialog-overlay hlm />
+		<ng-content />
+	`,
+})
+export class HlmDialog extends BrnDialog {}

--- a/libs/ui/form-field/src/index.ts
+++ b/libs/ui/form-field/src/index.ts
@@ -1,0 +1,9 @@
+import { HlmError } from './lib/hlm-error';
+import { HlmFormField } from './lib/hlm-form-field';
+import { HlmHint } from './lib/hlm-hint';
+
+export * from './lib/hlm-error';
+export * from './lib/hlm-form-field';
+export * from './lib/hlm-hint';
+
+export const HlmFormFieldImports = [HlmFormField, HlmError, HlmHint] as const;

--- a/libs/ui/form-field/src/lib/hlm-error.ts
+++ b/libs/ui/form-field/src/lib/hlm-error.ts
@@ -1,0 +1,17 @@
+import { computed, Directive, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'hlm-error',
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmError {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('text-destructive block text-sm font-medium', this.userClass()),
+	);
+}

--- a/libs/ui/form-field/src/lib/hlm-form-field.ts
+++ b/libs/ui/form-field/src/lib/hlm-form-field.ts
@@ -1,0 +1,52 @@
+import {
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	contentChild,
+	contentChildren,
+	effect,
+	input,
+} from '@angular/core';
+import { BrnFormFieldControl } from '@spartan-ng/brain/form-field';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+import { HlmError } from './hlm-error';
+
+@Component({
+	selector: 'hlm-form-field',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-content />
+
+		@switch (_hasDisplayedMessage()) {
+			@case ('error') {
+				<ng-content select="hlm-error" />
+			}
+			@default {
+				<ng-content select="hlm-hint" />
+			}
+		}
+	`,
+})
+export class HlmFormField {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('block space-y-2', this.userClass()));
+	public readonly control = contentChild(BrnFormFieldControl);
+
+	public readonly errorChildren = contentChildren(HlmError);
+
+	protected readonly _hasDisplayedMessage = computed<'error' | 'hint'>(() =>
+		this.errorChildren() && this.errorChildren().length > 0 && this.control()?.errorState() ? 'error' : 'hint',
+	);
+
+	constructor() {
+		effect(() => {
+			if (!this.control()) {
+				throw new Error('hlm-form-field must contain a BrnFormFieldControl.');
+			}
+		});
+	}
+}

--- a/libs/ui/form-field/src/lib/hlm-hint.ts
+++ b/libs/ui/form-field/src/lib/hlm-hint.ts
@@ -1,0 +1,15 @@
+import { computed, Directive, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'hlm-hint',
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmHint {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('text-muted-foreground block text-sm', this.userClass()));
+}

--- a/libs/ui/label/src/index.ts
+++ b/libs/ui/label/src/index.ts
@@ -1,0 +1,5 @@
+import { HlmLabel } from './lib/hlm-label';
+
+export * from './lib/hlm-label';
+
+export const HlmLabelImports = [HlmLabel] as const;

--- a/libs/ui/label/src/lib/hlm-label.ts
+++ b/libs/ui/label/src/lib/hlm-label.ts
@@ -1,0 +1,27 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnLabel } from '@spartan-ng/brain/label';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmLabel]',
+	hostDirectives: [
+		{
+			directive: BrnLabel,
+			inputs: ['id'],
+		},
+	],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmLabel {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 peer-data-[disabled]:cursor-not-allowed peer-data-[disabled]:opacity-50 has-[[disabled]]:cursor-not-allowed has-[[disabled]]:opacity-50',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/select/src/index.ts
+++ b/libs/ui/select/src/index.ts
@@ -1,0 +1,31 @@
+import { HlmSelect } from './lib/hlm-select';
+import { HlmSelectContent } from './lib/hlm-select-content';
+import { HlmSelectGroup } from './lib/hlm-select-group';
+import { HlmSelectLabel } from './lib/hlm-select-label';
+import { HlmSelectOption } from './lib/hlm-select-option';
+import { HlmSelectScrollDown } from './lib/hlm-select-scroll-down';
+import { HlmSelectScrollUp } from './lib/hlm-select-scroll-up';
+import { HlmSelectTrigger } from './lib/hlm-select-trigger';
+import { HlmSelectValue } from './lib/hlm-select-value';
+
+export * from './lib/hlm-select';
+export * from './lib/hlm-select-content';
+export * from './lib/hlm-select-group';
+export * from './lib/hlm-select-label';
+export * from './lib/hlm-select-option';
+export * from './lib/hlm-select-scroll-down';
+export * from './lib/hlm-select-scroll-up';
+export * from './lib/hlm-select-trigger';
+export * from './lib/hlm-select-value';
+
+export const HlmSelectImports = [
+	HlmSelectContent,
+	HlmSelectTrigger,
+	HlmSelectOption,
+	HlmSelectValue,
+	HlmSelect,
+	HlmSelectScrollUp,
+	HlmSelectScrollDown,
+	HlmSelectLabel,
+	HlmSelectGroup,
+] as const;

--- a/libs/ui/select/src/lib/hlm-select-content.ts
+++ b/libs/ui/select/src/lib/hlm-select-content.ts
@@ -1,0 +1,29 @@
+import type { BooleanInput } from '@angular/cdk/coercion';
+import { Directive, booleanAttribute, computed, input } from '@angular/core';
+import { injectExposedSideProvider, injectExposesStateProvider } from '@spartan-ng/brain/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmSelectContent], hlm-select-content',
+	host: {
+		'[class]': '_computedClass()',
+		'[attr.data-state]': '_stateProvider?.state() ?? "open"',
+		'[attr.data-side]': '_sideProvider?.side() ?? "bottom"',
+	},
+})
+export class HlmSelectContent {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly stickyLabels = input<boolean, BooleanInput>(false, {
+		transform: booleanAttribute,
+	});
+	protected readonly _stateProvider = injectExposesStateProvider({ optional: true });
+	protected readonly _sideProvider = injectExposedSideProvider({ optional: true });
+
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'border-border bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 w-full min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md data-[side=bottom]:top-[2px] data-[side=top]:bottom-[2px]',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select-group.ts
+++ b/libs/ui/select/src/lib/hlm-select-group.ts
@@ -1,0 +1,16 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnSelectGroup } from '@spartan-ng/brain/select';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmSelectGroup], hlm-select-group',
+	hostDirectives: [BrnSelectGroup],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmSelectGroup {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm(this.userClass()));
+}

--- a/libs/ui/select/src/lib/hlm-select-label.ts
+++ b/libs/ui/select/src/lib/hlm-select-label.ts
@@ -1,0 +1,25 @@
+import { Directive, computed, inject, input } from '@angular/core';
+import { BrnSelectLabel } from '@spartan-ng/brain/select';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+import { HlmSelectContent } from './hlm-select-content';
+
+@Directive({
+	selector: '[hlmSelectLabel], hlm-select-label',
+	hostDirectives: [BrnSelectLabel],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmSelectLabel {
+	private readonly _selectContent = inject(HlmSelectContent);
+	private readonly _stickyLabels = computed(() => this._selectContent.stickyLabels());
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'text-muted-foreground px-2 py-1.5 text-xs',
+			this._stickyLabels() ? 'bg-popover sticky top-0 z-[2] block' : '',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select-option.ts
+++ b/libs/ui/select/src/lib/hlm-select-option.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck } from '@ng-icons/lucide';
+import { BrnSelectOption } from '@spartan-ng/brain/select';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-option',
+	imports: [NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideCheck })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	hostDirectives: [{ directive: BrnSelectOption, inputs: ['disabled', 'value'] }],
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<span class="absolute right-2 flex size-3.5 items-center justify-center">
+			@if (this._brnSelectOption.selected()) {
+				<ng-icon hlm size="sm" aria-hidden="true" name="lucideCheck" />
+			}
+		</span>
+
+		<ng-content />
+	`,
+})
+export class HlmSelectOption {
+	protected readonly _brnSelectOption = inject(BrnSelectOption, { host: true });
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'data-[active]:bg-accent data-[active]:text-accent-foreground [&>ng-icon]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 [&>ng-icon]:pointer-events-none [&>ng-icon]:size-4 [&>ng-icon]:shrink-0',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select-scroll-down.ts
+++ b/libs/ui/select/src/lib/hlm-select-scroll-down.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronDown } from '@ng-icons/lucide';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-select-scroll-down',
+	imports: [NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideChevronDown })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-icon hlm size="sm" class="ml-2" name="lucideChevronDown" />
+	`,
+})
+export class HlmSelectScrollDown {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('flex cursor-default items-center justify-center py-1', this.userClass()),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select-scroll-up.ts
+++ b/libs/ui/select/src/lib/hlm-select-scroll-up.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronUp } from '@ng-icons/lucide';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-select-scroll-up',
+	imports: [NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideChevronUp })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<ng-icon hlm size="sm" class="ml-2" name="lucideChevronUp" />
+	`,
+})
+export class HlmSelectScrollUp {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('flex cursor-default items-center justify-center py-1', this.userClass()),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select-trigger.ts
+++ b/libs/ui/select/src/lib/hlm-select-trigger.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component, computed, contentChild, inject, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronDown } from '@ng-icons/lucide';
+import { BrnSelect, BrnSelectTrigger } from '@spartan-ng/brain/select';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import { cva } from 'class-variance-authority';
+import type { ClassValue } from 'clsx';
+
+export const selectTriggerVariants = cva(
+	`border-input [&>ng-icon]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 [&>ng-icon]:pointer-events-none [&>ng-icon]:size-4 [&>ng-icon]:shrink-0`,
+	{
+		variants: {
+			error: {
+				auto: '[&.ng-invalid.ng-touched]:text-destructive [&.ng-invalid.ng-touched]:border-destructive [&.ng-invalid.ng-touched]:focus-visible:ring-destructive/20 dark:[&.ng-invalid.ng-touched]:focus-visible:ring-destructive/40',
+				true: 'text-destructive border-destructive focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40',
+			},
+		},
+		defaultVariants: {
+			error: 'auto',
+		},
+	},
+);
+
+@Component({
+	selector: 'hlm-select-trigger',
+	imports: [BrnSelectTrigger, NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideChevronDown })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<button [class]="_computedClass()" #button hlmInput brnSelectTrigger type="button" [attr.data-size]="size()">
+			<ng-content />
+			@if (_icon()) {
+				<ng-content select="ng-icon" />
+			} @else {
+				<ng-icon hlm size="sm" class="ml-2 flex-none" name="lucideChevronDown" />
+			}
+		</button>
+	`,
+})
+export class HlmSelectTrigger {
+	protected readonly _icon = contentChild(HlmIcon);
+
+	protected readonly _brnSelect = inject(BrnSelect, { optional: true });
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+
+	public readonly size = input<'default' | 'sm'>('default');
+
+	protected readonly _computedClass = computed(() =>
+		hlm(selectTriggerVariants({ error: this._brnSelect?.errorState() }), this.userClass()),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select-value.ts
+++ b/libs/ui/select/src/lib/hlm-select-value.ts
@@ -1,0 +1,16 @@
+import { Directive, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: 'hlm-select-value,[hlmSelectValue], brn-select-value[hlm]',
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmSelectValue {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('data-[placeholder]:text-muted-foreground line-clamp-1 flex items-center gap-2 truncate', this.userClass()),
+	);
+}

--- a/libs/ui/select/src/lib/hlm-select.ts
+++ b/libs/ui/select/src/lib/hlm-select.ts
@@ -1,0 +1,14 @@
+import { Directive, computed, input } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: 'hlm-select, brn-select [hlm]',
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmSelect {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('space-y-2', this.userClass()));
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,6 +2,7 @@
   <!-- Menubar -->
   <spartan-menubar
     (openTargetManagerEvent)="openTargetManager($event)"
+    (openCommandRunnerEvent)="openCommandRunner()"
   ></spartan-menubar>
 
   <div class="app-layout flex-1 flex overflow-hidden">
@@ -29,6 +30,22 @@
         [mode]="targetManagerMode"
         (closeEvent)="closeTargetManager()"
       ></app-target-manager>
+    </div>
+  </div>
+
+  <!-- Modal Command Runner -->
+  <div 
+    *ngIf="commandRunnerVisible" 
+    class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+    (click)="closeCommandRunner()"
+  >
+    <div 
+      class="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-5xl w-full h-[80vh] overflow-hidden m-4"
+      (click)="$event.stopPropagation()"
+    >
+      <app-command-runner
+        (closeEvent)="closeCommandRunner()"
+      ></app-command-runner>
     </div>
   </div>
 </div>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,7 +2,7 @@
   <!-- Menubar -->
   <spartan-menubar
     (openTargetManagerEvent)="openTargetManager($event)"
-    (openCommandRunnerEvent)="openCommandRunner()"
+    (openCommandRunnerEvent)="openCommandRunner($event)"
   ></spartan-menubar>
 
   <div class="app-layout flex-1 flex overflow-hidden">
@@ -44,6 +44,7 @@
       (click)="$event.stopPropagation()"
     >
       <app-command-runner
+        [initialToolId]="selectedToolId"
         (closeEvent)="closeCommandRunner()"
       ></app-command-runner>
     </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,11 +4,12 @@ import { CommonModule } from '@angular/common';
 import { Menubar } from '../ui/menubar/menubar';
 import { ChatSidebar } from '../ui/sidebar/chat-sidebar';
 import { TargetManagerComponent } from '../ui/target-manager/target-manager.component';
+import { CommandRunnerComponent } from '../ui/command-runner/command-runner.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CommonModule, RouterOutlet, Menubar, ChatSidebar, TargetManagerComponent],
+  imports: [CommonModule, RouterOutlet, Menubar, ChatSidebar, TargetManagerComponent, CommandRunnerComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css'],
 })
@@ -17,6 +18,7 @@ export class App {
   
   targetManagerVisible = false;
   targetManagerMode: 'view' | 'add' | 'delete' = 'view';
+  commandRunnerVisible = false;
   
   @ViewChild('targetManager', { static: false }) targetManager?: TargetManagerComponent;
 
@@ -33,6 +35,14 @@ export class App {
 
   closeTargetManager() {
     this.targetManagerVisible = false;
+  }
+
+  openCommandRunner() {
+    this.commandRunnerVisible = true;
+  }
+
+  closeCommandRunner() {
+    this.commandRunnerVisible = false;
   }
 
   saveTargets() {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -19,6 +19,7 @@ export class App {
   targetManagerVisible = false;
   targetManagerMode: 'view' | 'add' | 'delete' = 'view';
   commandRunnerVisible = false;
+  selectedToolId: string = '';
   
   @ViewChild('targetManager', { static: false }) targetManager?: TargetManagerComponent;
 
@@ -37,7 +38,8 @@ export class App {
     this.targetManagerVisible = false;
   }
 
-  openCommandRunner() {
+  openCommandRunner(toolId?: string) {
+    this.selectedToolId = toolId || '';
     this.commandRunnerVisible = true;
   }
 

--- a/src/app/core/constants/tools.ts
+++ b/src/app/core/constants/tools.ts
@@ -1,0 +1,59 @@
+export enum ToolCategory {
+  DISCOVERY = 'Discovery',
+  WEB = 'Web',
+  REVERSE_SHELL = 'Reverse Shell',
+  EXPLOIT = 'Exploit',
+  OTHER = 'Other'
+}
+
+export interface Tool {
+  id: string;
+  name: string;
+  category: ToolCategory;
+  template: string;
+}
+
+export const TOOLS: Tool[] = [
+  { 
+    id: 'nmap', 
+    name: 'Nmap Scan', 
+    category: ToolCategory.DISCOVERY, 
+    template: 'nmap -sV -p- {host}' 
+  },
+  { 
+    id: 'ping', 
+    name: 'Ping', 
+    category: ToolCategory.DISCOVERY, 
+    template: 'ping -c 4 {host}' 
+  },
+  { 
+    id: 'whois', 
+    name: 'Whois', 
+    category: ToolCategory.DISCOVERY, 
+    template: 'whois {host}' 
+  },
+  { 
+    id: 'gobuster', 
+    name: 'Gobuster Dir', 
+    category: ToolCategory.WEB, 
+    template: 'gobuster dir -u http://{host}:{port} -w common.txt' 
+  },
+  { 
+    id: 'ffuf', 
+    name: 'FFuF Fuzz', 
+    category: ToolCategory.WEB, 
+    template: 'ffuf -u http://{host}:{port}/FUZZ -w common.txt' 
+  },
+  { 
+    id: 'nikto', 
+    name: 'Nikto Scan', 
+    category: ToolCategory.WEB, 
+    template: 'nikto -h http://{host}:{port}' 
+  },
+  {
+      id: 'netcat_rev',
+      name: 'Netcat Listener',
+      category: ToolCategory.REVERSE_SHELL,
+      template: 'nc -lvnp {port}'
+  }
+];

--- a/src/app/core/services/target.service.ts
+++ b/src/app/core/services/target.service.ts
@@ -7,6 +7,7 @@ export interface Target {
   port?: number;
   description?: string;
   createdAt: string;
+  commands?: Record<string, string>;
 }
 
 @Injectable({
@@ -73,6 +74,23 @@ export class TargetService {
     const deletedCount = targets.length - filtered.length;
     
     this.saveTargets(filtered);
+    this.saveTargets(filtered);
     return deletedCount;
+  }
+
+  saveTargetCommand(targetId: string, tool: string, command: string): boolean {
+    const targets = this.getTargets();
+    const index = targets.findIndex(t => t.id === targetId);
+
+    if (index === -1) return false;
+
+    const target = targets[index];
+    const commands = target.commands || {};
+    commands[tool] = command;
+
+    targets[index] = { ...target, commands };
+    this.saveTargets(targets);
+
+    return true;
   }
 }

--- a/src/ui/command-runner/command-runner.component.ts
+++ b/src/ui/command-runner/command-runner.component.ts
@@ -16,6 +16,8 @@ import {
   lucideLoader, 
   lucideCircleHelp 
 } from '@ng-icons/lucide';
+import { TOOLS } from '../../app/core/constants/tools';
+import { Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { BrnSelectImports } from '@spartan-ng/brain/select';
 import { BrnDialogImports } from '@spartan-ng/brain/dialog';
@@ -199,15 +201,11 @@ export class CommandRunnerComponent implements OnInit, OnDestroy {
   // Help State
   isHelpRunning = false;
   helpOutput: SafeHtml | null = null;
+  
+  @Input() initialToolId: string = '';
 
   // Tools definition
-  readonly tools = [
-    { id: 'nmap', name: 'Nmap Scan', template: 'nmap -sV -p- {host}' },
-    { id: 'gobuster', name: 'Gobuster Dir', template: 'gobuster dir -u http://{host}:{port} -w common.txt' },
-    { id: 'ffuf', name: 'FFuF Fuzz', template: 'ffuf -u http://{host}:{port}/FUZZ -w common.txt' },
-    { id: 'ping', name: 'Ping', template: 'ping -c 4 {host}' },
-    { id: 'whois', name: 'Whois', template: 'whois {host}' }
-  ];
+  readonly tools = TOOLS;
 
   private ansiConverter = new AnsiToHtml({
     fg: '#d4d4d4',
@@ -221,6 +219,15 @@ export class CommandRunnerComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.targets = this.targetService.getTargets();
+    if (this.initialToolId) {
+        this.selectTool(this.initialToolId);
+    }
+  }
+  
+  ngOnChanges(changes: SimpleChanges) {
+      if (changes['initialToolId'] && changes['initialToolId'].currentValue) {
+          this.selectTool(changes['initialToolId'].currentValue);
+      }
   }
 
   ngOnDestroy() {

--- a/src/ui/command-runner/command-runner.component.ts
+++ b/src/ui/command-runner/command-runner.component.ts
@@ -72,22 +72,36 @@ import { HlmDialogImports } from '@ctfdeck/helm/dialog';
         
         <!-- Left: Target & Tool -->
         <div class="space-y-6">
+            <!-- Target Section -->
             <div class="space-y-2">
-                <label hlmLabel>Target</label>
-                <brn-select hlm class="w-full" [(ngModel)]="selectedTargetId" (ngModelChange)="onTargetChange()" placeholder="Select a target...">
-                    <hlm-select-trigger class="w-full">
-                        <hlm-select-value />
-                    </hlm-select-trigger>
-                    <hlm-select-content class="max-h-60">
-                        <hlm-option *ngFor="let target of targets" [value]="target.id">
-                            {{ target.name }} ({{ target.host }})
-                        </hlm-option>
-                    </hlm-select-content>
-                </brn-select>
+                <div class="flex justify-between items-center h-9">
+                    <label hlmLabel>Target</label>
+                </div>
+                
+                <ng-container *ngIf="targets.length > 0; else noTargets">
+                    <brn-select hlm class="w-full" [(ngModel)]="selectedTargetId" (ngModelChange)="onTargetChange()" placeholder="Select a target...">
+                        <hlm-select-trigger class="w-full">
+                            <hlm-select-value />
+                        </hlm-select-trigger>
+                        <hlm-select-content class="max-h-60">
+                            <hlm-option *ngFor="let target of targets" [value]="target.id">
+                                {{ target.name }} ({{ target.host }})
+                            </hlm-option>
+                        </hlm-select-content>
+                    </brn-select>
+                </ng-container>
+                <ng-template #noTargets>
+                    <div class="flex items-center justify-center p-3 border border-dashed border-border rounded-md bg-muted/50 text-muted-foreground text-sm">
+                        No targets available
+                    </div>
+                </ng-template>
             </div>
 
+            <!-- Tool Section -->
             <div class="space-y-2">
-                <label hlmLabel>Tool</label>
+                <div class="flex justify-between items-center h-9">
+                    <label hlmLabel>Tool</label>
+                </div>
                 <div class="flex flex-wrap gap-2">
                     <button *ngFor="let tool of tools"
                             hlmBtn
@@ -103,15 +117,16 @@ import { HlmDialogImports } from '@ctfdeck/helm/dialog';
         <!-- Right: Command & Controls -->
         <div class="space-y-6">
             <div class="space-y-2">
-                 <div class="flex justify-between items-center">
+                 <div class="flex justify-between items-center h-9">
                     <label hlmLabel>Command</label>
-                    <button hlmBtn variant="ghost" size="icon" class="h-6 w-6" (click)="saveCommand()" title="Save as default">
-                        <ng-icon hlm name="lucideSave" size="sm" />
-                    </button>
                  </div>
                  <div class="flex gap-2">
                     <input hlmInput class="flex-1 font-mono" [(ngModel)]="currentCommand" placeholder="Select target & tool..." />
                     
+                    <button hlmBtn variant="outline" size="icon" (click)="saveCommand()" title="Save as default">
+                        <ng-icon hlm name="lucideSave" size="sm" />
+                    </button>
+
                     <!-- Help Dialog Trigger -->
                     <hlm-dialog>
                         <button brnDialogTrigger hlmBtn variant="outline" size="icon" (click)="runHelp()" [disabled]="!selectedToolId" title="Show Help">

--- a/src/ui/command-runner/command-runner.component.ts
+++ b/src/ui/command-runner/command-runner.component.ts
@@ -1,0 +1,349 @@
+import { Component, EventEmitter, Output, inject, ChangeDetectorRef, ViewChild, ElementRef, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { TargetService, Target } from '../../app/core/services/target.service';
+import { WebSocketService } from '../../app/core/services/websocket.service';
+import AnsiToHtml from 'ansi-to-html';
+import { Subscription } from 'rxjs';
+import { provideIcons } from '@ng-icons/core';
+import { 
+  lucideTerminal, 
+  lucideX, 
+  lucideSave, 
+  lucidePlay, 
+  lucideSquare, 
+  lucideLoader, 
+  lucideCircleHelp 
+} from '@ng-icons/lucide';
+
+import { BrnSelectImports } from '@spartan-ng/brain/select';
+import { BrnDialogImports } from '@spartan-ng/brain/dialog';
+import { HlmSelectImports } from '@ctfdeck/helm/select';
+import { HlmButtonImports } from '@ctfdeck/helm/button';
+import { HlmInputImports } from '@ctfdeck/helm/input';
+import { HlmIconImports } from '@ctfdeck/helm/icon';
+import { HlmLabelImports } from '@ctfdeck/helm/label';
+import { HlmDialogImports } from '@ctfdeck/helm/dialog';
+
+@Component({
+  selector: 'app-command-runner',
+  standalone: true,
+  imports: [
+    CommonModule, 
+    FormsModule,
+    ...BrnSelectImports,
+    ...BrnDialogImports,
+    ...HlmSelectImports,
+    ...HlmButtonImports,
+    ...HlmInputImports,
+    ...HlmIconImports,
+    ...HlmLabelImports,
+    ...HlmDialogImports
+  ],
+  providers: [
+    provideIcons({ 
+      lucideTerminal, 
+      lucideX, 
+      lucideSave, 
+      lucidePlay, 
+      lucideSquare, 
+      lucideLoader, 
+      lucideCircleHelp 
+    })
+  ],
+  template: `
+    <div class="h-full flex flex-col bg-background text-foreground p-6">
+      <!-- Header -->
+      <div class="flex justify-between items-center mb-6 border-b border-border pb-4">
+        <div class="flex items-center gap-2">
+            <ng-icon hlm name="lucideTerminal" class="text-primary text-2xl" />
+            <h2 class="text-2xl font-bold tracking-tight">Command Runner</h2>
+        </div>
+        <button hlmBtn variant="ghost" size="icon" (click)="close()">
+          <ng-icon hlm name="lucideX" />
+        </button>
+      </div>
+
+      <!-- Settings Grid -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-6">
+        
+        <!-- Left: Target & Tool -->
+        <div class="space-y-6">
+            <div class="space-y-2">
+                <label hlmLabel>Target</label>
+                <brn-select hlm class="w-full" [(ngModel)]="selectedTargetId" (ngModelChange)="onTargetChange()" placeholder="Select a target...">
+                    <hlm-select-trigger class="w-full">
+                        <hlm-select-value />
+                    </hlm-select-trigger>
+                    <hlm-select-content class="max-h-60">
+                        <hlm-option *ngFor="let target of targets" [value]="target.id">
+                            {{ target.name }} ({{ target.host }})
+                        </hlm-option>
+                    </hlm-select-content>
+                </brn-select>
+            </div>
+
+            <div class="space-y-2">
+                <label hlmLabel>Tool</label>
+                <div class="flex flex-wrap gap-2">
+                    <button *ngFor="let tool of tools"
+                            hlmBtn
+                            [variant]="selectedToolId === tool.id ? 'default' : 'outline'"
+                            size="sm"
+                            (click)="selectTool(tool.id)">
+                        {{ tool.name }}
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Right: Command & Controls -->
+        <div class="space-y-6">
+            <div class="space-y-2">
+                 <div class="flex justify-between items-center">
+                    <label hlmLabel>Command</label>
+                    <button hlmBtn variant="ghost" size="icon" class="h-6 w-6" (click)="saveCommand()" title="Save as default">
+                        <ng-icon hlm name="lucideSave" size="sm" />
+                    </button>
+                 </div>
+                 <div class="flex gap-2">
+                    <input hlmInput class="flex-1 font-mono" [(ngModel)]="currentCommand" placeholder="Select target & tool..." />
+                    
+                    <!-- Help Dialog Trigger -->
+                    <hlm-dialog>
+                        <button brnDialogTrigger hlmBtn variant="outline" size="icon" (click)="runHelp()" [disabled]="!selectedToolId" title="Show Help">
+                            <ng-icon hlm name="lucideCircleHelp" />
+                        </button>
+                        <hlm-dialog-content *brnDialogContent="let ctx" class="max-w-3xl max-h-[80vh] flex flex-col">
+                            <hlm-dialog-header>
+                                <h3 hlmDialogTitle>Help: {{selectedToolId}}</h3>
+                                <p hlmDialogDescription>
+                                    Output of <code>{{selectedToolId}} -h</code>
+                                </p>
+                            </hlm-dialog-header>
+                            
+                            <div class="flex-1 overflow-auto bg-slate-950 p-4 rounded-md mt-2 border border-slate-800">
+                                <div *ngIf="isHelpRunning" class="flex items-center gap-2 text-muted-foreground">
+                                    <ng-icon hlm name="lucideLoader" class="animate-spin" /> Loading help...
+                                </div>
+                                <div *ngIf="!isHelpRunning" class="font-mono text-xs whitespace-pre-wrap text-slate-300" [innerHTML]="helpOutput"></div>
+                            </div>
+
+                            <hlm-dialog-footer class="mt-4">
+                                <button hlmBtn variant="outline" (click)="ctx.close()">Close</button>
+                            </hlm-dialog-footer>
+                        </hlm-dialog-content>
+                    </hlm-dialog>
+                 </div>
+                 <p class="text-xs text-muted-foreground">
+                    Customize the command and click <ng-icon hlm name="lucideSave" class="inline h-3 w-3" /> to save.
+                 </p>
+            </div>
+
+            <div class="flex justify-end gap-3 pt-2">
+                <button *ngIf="isRunning" hlmBtn variant="destructive" (click)="stopCommand()" class="gap-2">
+                    <ng-icon hlm name="lucideSquare" class="h-4 w-4" /> Stop
+                </button>
+                <button hlmBtn [disabled]="isRunning || !currentCommand" (click)="runCommand()" class="gap-2 min-w-[120px]">
+                    <ng-icon hlm [name]="isRunning ? 'lucideLoader' : 'lucidePlay'" [class]="isRunning ? 'animate-spin h-4 w-4' : 'h-4 w-4'" /> 
+                    {{ isRunning ? 'Running...' : 'Run' }}
+                </button>
+            </div>
+        </div>
+      </div>
+
+
+      <!-- Output Terminal -->
+      <div class="flex-1 flex flex-col min-h-0 rounded-md border border-border bg-[#1e1e1e] overflow-hidden">
+        <div class="flex justify-between items-center px-4 py-2 border-b border-white/10 bg-white/5">
+            <span class="text-xs font-medium text-slate-400">Terminal Output</span>
+            <button class="text-xs text-slate-400 hover:text-white transition-colors" (click)="clearOutput()">Clear</button>
+        </div>
+        <div #outputContainer class="flex-1 overflow-auto p-4 font-mono text-sm leading-relaxed whitespace-pre-wrap text-[#d4d4d4]">
+             <div *ngFor="let line of outputLines" [innerHTML]="line"></div>
+             <div *ngIf="outputLines.length === 0" class="text-slate-600 italic">
+                Ready to execute...
+             </div>
+        </div>
+      </div>
+
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      height: 100%;
+    }
+  `]
+})
+export class CommandRunnerComponent implements OnInit, OnDestroy {
+  @Output() closeEvent = new EventEmitter<void>();
+  
+  private targetService = inject(TargetService);
+  private wsService = inject(WebSocketService);
+  private cdr = inject(ChangeDetectorRef);
+  private sanitizer = inject(DomSanitizer);
+
+  @ViewChild('outputContainer') private outputContainer!: ElementRef;
+
+  targets: Target[] = [];
+  selectedTargetId: string = '';
+  selectedToolId: string = '';
+  currentCommand: string = '';
+  isRunning: boolean = false;
+  
+  outputLines: SafeHtml[] = [];
+  private subscriptions: Subscription = new Subscription();
+
+  // Help State
+  isHelpRunning = false;
+  helpOutput: SafeHtml | null = null;
+
+  // Tools definition
+  readonly tools = [
+    { id: 'nmap', name: 'Nmap Scan', template: 'nmap -sV -p- {host}' },
+    { id: 'gobuster', name: 'Gobuster Dir', template: 'gobuster dir -u http://{host}:{port} -w common.txt' },
+    { id: 'ffuf', name: 'FFuF Fuzz', template: 'ffuf -u http://{host}:{port}/FUZZ -w common.txt' },
+    { id: 'ping', name: 'Ping', template: 'ping -c 4 {host}' },
+    { id: 'whois', name: 'Whois', template: 'whois {host}' }
+  ];
+
+  private ansiConverter = new AnsiToHtml({
+    fg: '#d4d4d4',
+    bg: '#1e1e1e',
+    newline: true,
+    colors: {
+        4: '#61afef', 
+        34: '#61afef',
+    },
+  });
+
+  ngOnInit() {
+    this.targets = this.targetService.getTargets();
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
+  close() {
+    this.closeEvent.emit();
+  }
+
+  onTargetChange() {
+    this.updateCommandPreview();
+  }
+
+  selectTool(toolId: string) {
+    this.selectedToolId = toolId;
+    this.updateCommandPreview();
+  }
+
+  updateCommandPreview() {
+    if (!this.selectedTargetId || !this.selectedToolId) return;
+
+    const target = this.targets.find(t => t.id === this.selectedTargetId);
+    if (!target) return;
+
+    // Check if we have a saved command for this target+tool
+    if (target.commands && target.commands[this.selectedToolId]) {
+      this.currentCommand = target.commands[this.selectedToolId];
+    } else {
+      // Generate from template
+      const tool = this.tools.find(t => t.id === this.selectedToolId);
+      if (tool) {
+        let cmd = tool.template;
+        cmd = cmd.replace(/{host}/g, target.host);
+        cmd = cmd.replace(/{port}/g, (target.port || (cmd.includes('http') ? 80 : '')).toString());
+        this.currentCommand = cmd;
+      }
+    }
+  }
+
+  saveCommand() {
+    if (this.selectedTargetId && this.selectedToolId && this.currentCommand) {
+      this.targetService.saveTargetCommand(this.selectedTargetId, this.selectedToolId, this.currentCommand);
+      this.targets = this.targetService.getTargets();
+    }
+  }
+
+  runCommand() {
+    if (!this.currentCommand) return;
+    
+    this.isRunning = true;
+    this.outputLines = [];
+    this.addLine(`<span class="text-blue-400">Running: ${this.currentCommand}</span>`);
+
+    this.wsService.executeCommandStreaming(
+      this.currentCommand,
+      (data) => {
+        this.appendOutput(data);
+      },
+      (error) => {
+        this.appendOutput(error, true);
+      }
+    ).then((result: any) => {
+      this.isRunning = false;
+      this.addLine(`<span class="text-green-400">Done. Exit code: ${result.exitCode}</span>`);
+      this.cdr.detectChanges();
+    }).catch((err: any) => {
+        this.isRunning = false;
+        this.addLine(`<span class="text-red-500">Error: ${err.message}</span>`);
+        this.cdr.detectChanges();
+    });
+  }
+
+  stopCommand() {
+      this.isRunning = false;
+      this.addLine(`<span class="text-yellow-500">Stop requested (UI only)</span>`);
+  }
+
+  clearOutput() {
+    this.outputLines = [];
+  }
+
+  // Help Logic
+  runHelp() {
+      if (!this.selectedToolId) return;
+      
+      this.isHelpRunning = true;
+      this.helpOutput = null; // Clear previous help
+      
+      let outputAcc = '';
+      this.wsService.executeCommandStreaming(
+        `${this.selectedToolId} -h`,
+        (data) => outputAcc += data, 
+        (error) => outputAcc += error
+      ).then(() => {
+          this.isHelpRunning = false;
+          const html = this.ansiConverter.toHtml(outputAcc);
+          this.helpOutput = this.sanitizer.bypassSecurityTrustHtml(html);
+          this.cdr.detectChanges();
+      }).catch((err: any) => {
+          this.isHelpRunning = false;
+          this.helpOutput = this.sanitizer.bypassSecurityTrustHtml(`<span class="text-red-500">Error running help: ${err.message}</span>`);
+          this.cdr.detectChanges();
+      });
+  }
+
+  private appendOutput(data: string, isError: boolean = false) {
+    const html = this.ansiConverter.toHtml(data);
+    this.addLine(html);
+  }
+
+  private addLine(htmlContent: string) {
+    const safeHtml = this.sanitizer.bypassSecurityTrustHtml(htmlContent);
+    this.outputLines.push(safeHtml);
+    this.cdr.detectChanges();
+    this.scrollToBottom();
+  }
+
+  private scrollToBottom() {
+    setTimeout(() => {
+      if (this.outputContainer) {
+        this.outputContainer.nativeElement.scrollTop = this.outputContainer.nativeElement.scrollHeight;
+      }
+    }, 0);
+  }
+}

--- a/src/ui/menubar/menubar.html
+++ b/src/ui/menubar/menubar.html
@@ -22,6 +22,7 @@
         <button hlmMenuItem (click)="openTargetManager('view')">Configuration</button>
         <button hlmMenuItem (click)="openTargetManager('add')">Ajout d'une cible</button>
         <button hlmMenuItem (click)="openTargetManager('delete')">Retrait d'une cible</button>
+        <button hlmMenuItem (click)="openCommandRunner()">Exécuter des commandes</button>
         <button hlmMenuItem (click)="saveTargets()">Sauvegarde d'une cible</button>
       </hlm-menu-group>
     </hlm-menu>

--- a/src/ui/menubar/menubar.html
+++ b/src/ui/menubar/menubar.html
@@ -22,7 +22,6 @@
         <button hlmMenuItem (click)="openTargetManager('view')">Configuration</button>
         <button hlmMenuItem (click)="openTargetManager('add')">Ajout d'une cible</button>
         <button hlmMenuItem (click)="openTargetManager('delete')">Retrait d'une cible</button>
-        <button hlmMenuItem (click)="openCommandRunner()">Exécuter des commandes</button>
         <button hlmMenuItem (click)="saveTargets()">Sauvegarde d'une cible</button>
       </hlm-menu-group>
     </hlm-menu>
@@ -31,11 +30,56 @@
   <ng-template #scripts>
     <hlm-menu variant="menubar" class="w-48">
       <hlm-menu-group>
-        <button hlmMenuItem>Web</button>
-        <button hlmMenuItem>Reverse shell</button>
-        <button hlmMenuItem>Reverse engineering</button>
+        <button hlmMenuItem align="start" side="right" [brnMenuTriggerFor]="discovery">
+            Discovery
+            <hlm-menu-item-sub-indicator />
+        </button>
+        <button hlmMenuItem align="start" side="right" [brnMenuTriggerFor]="web">
+            Web
+            <hlm-menu-item-sub-indicator />
+        </button>
+        <button hlmMenuItem align="start" side="right" [brnMenuTriggerFor]="revshell">
+            Reverse Shell
+            <hlm-menu-item-sub-indicator />
+        </button>
+        <button hlmMenuItem align="start" side="right" [brnMenuTriggerFor]="exploit">
+            Exploit
+            <hlm-menu-item-sub-indicator />
+        </button>
       </hlm-menu-group>
     </hlm-menu>
+  </ng-template>
+
+  <ng-template #discovery>
+      <hlm-sub-menu>
+        <button hlmMenuItem *ngFor="let tool of getToolsByCategory(ToolCategory.DISCOVERY)" (click)="openCommandRunner(tool.id)">
+            {{ tool.name }}
+        </button>
+      </hlm-sub-menu>
+  </ng-template>
+
+  <ng-template #web>
+      <hlm-sub-menu>
+        <button hlmMenuItem *ngFor="let tool of getToolsByCategory(ToolCategory.WEB)" (click)="openCommandRunner(tool.id)">
+            {{ tool.name }}
+        </button>
+      </hlm-sub-menu>
+  </ng-template>
+
+  <ng-template #revshell>
+      <hlm-sub-menu>
+        <button hlmMenuItem *ngFor="let tool of getToolsByCategory(ToolCategory.REVERSE_SHELL)" (click)="openCommandRunner(tool.id)">
+            {{ tool.name }}
+        </button>
+      </hlm-sub-menu>
+  </ng-template>
+
+  <ng-template #exploit>
+      <hlm-sub-menu>
+        <button hlmMenuItem *ngFor="let tool of getToolsByCategory(ToolCategory.EXPLOIT)" (click)="openCommandRunner(tool.id)">
+            {{ tool.name }}
+        </button>
+      </hlm-sub-menu>
   </ng-template>
 
   <ng-template #utils>

--- a/src/ui/menubar/menubar.ts
+++ b/src/ui/menubar/menubar.ts
@@ -35,6 +35,7 @@ export class Menubar {
   constructor(private router: Router) {}
   
   @Output() openTargetManagerEvent = new EventEmitter<'view' | 'add' | 'delete'>();
+  @Output() openCommandRunnerEvent = new EventEmitter<void>();
 
   navigate(path: string) {
     this.router.navigate([path]);
@@ -46,6 +47,10 @@ export class Menubar {
 
   openTargetManager(mode: 'view' | 'add' | 'delete') {
     this.openTargetManagerEvent.emit(mode);
+  }
+
+  openCommandRunner() {
+    this.openCommandRunnerEvent.emit();
   }
 
   saveTargets() {

--- a/src/ui/menubar/menubar.ts
+++ b/src/ui/menubar/menubar.ts
@@ -12,11 +12,14 @@ import {
   HlmSubMenu,
 } from '@ctfdeck/helm/menu';
 import { ThemeToggle } from './theme-toggle';
+import { TOOLS, ToolCategory } from '../../app/core/constants/tools';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'spartan-menubar',
   standalone: true,
   imports: [
+    CommonModule,
     BrnMenuTrigger,
     HlmMenu,
     HlmMenuBar,
@@ -35,7 +38,18 @@ export class Menubar {
   constructor(private router: Router) {}
   
   @Output() openTargetManagerEvent = new EventEmitter<'view' | 'add' | 'delete'>();
-  @Output() openCommandRunnerEvent = new EventEmitter<void>();
+  @Output() openCommandRunnerEvent = new EventEmitter<string | undefined>();
+
+  categories = [
+    ToolCategory.DISCOVERY,
+    ToolCategory.WEB,
+    ToolCategory.REVERSE_SHELL,
+    ToolCategory.EXPLOIT,
+    ToolCategory.OTHER
+  ];
+
+  tools = TOOLS;
+  protected readonly ToolCategory = ToolCategory;
 
   navigate(path: string) {
     this.router.navigate([path]);
@@ -49,8 +63,12 @@ export class Menubar {
     this.openTargetManagerEvent.emit(mode);
   }
 
-  openCommandRunner() {
-    this.openCommandRunnerEvent.emit();
+  openCommandRunner(toolId?: string) {
+    this.openCommandRunnerEvent.emit(toolId);
+  }
+
+  getToolsByCategory(category: ToolCategory) {
+    return this.tools.filter(t => t.category === category);
   }
 
   saveTargets() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,21 @@
       ],
       "@ctfdeck/helm/textarea": [
         "./libs/ui/textarea/src/index.ts"
+      ],
+      "@ctfdeck/helm/alert-dialog": [
+        "./libs/ui/alert-dialog/src/index.ts"
+      ],
+      "@ctfdeck/helm/dialog": [
+        "./libs/ui/dialog/src/index.ts"
+      ],
+      "@ctfdeck/helm/select": [
+        "./libs/ui/select/src/index.ts"
+      ],
+      "@ctfdeck/helm/form-field": [
+        "./libs/ui/form-field/src/index.ts"
+      ],
+      "@ctfdeck/helm/label": [
+        "./libs/ui/label/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
<img width="1317" height="831" alt="image" src="https://github.com/user-attachments/assets/0e52c8ce-6253-407c-ad32-58029afb7478" />

This pull request introduces new "Helm" (Hlm) styled components for both the Alert Dialog and Dialog UI libraries, providing a consistent, customizable set of Angular components and directives for modal dialogs. These changes add new exports, directives, components, and a service to make it easier to use and style dialogs across the application.

**Alert Dialog Enhancements:**

- Added a full set of Hlm-styled components and directives for Alert Dialogs, including content, header, footer, overlay, title, description, action, and cancel buttons, all exported from the main index. (`index.ts`, `hlm-alert-dialog.ts`, `hlm-alert-dialog-content.ts`, `hlm-alert-dialog-header.ts`, `hlm-alert-dialog-footer.ts`, `hlm-alert-dialog-overlay.ts`, `hlm-alert-dialog-title.ts`, `hlm-alert-dialog-description.ts`, `hlm-alert-dialog-action-button.ts`, `hlm-alert-dialog-cancel-button.ts`) [[1]](diffhunk://#diff-b6ec8be3d6f8c9bb3e86e3a02d9952d8577e8d5711b026f1623391096c3146d0R1-R31) [[2]](diffhunk://#diff-570d406542af0140f14137409713e4a0db2abfffb09889c7ec5ffd68fc66c189R1-R29) [[3]](diffhunk://#diff-fe82090cca5d570b5779129273add0c66b1e4de61acfcc50ed0499b76d86d965R1-R28) [[4]](diffhunk://#diff-65e737628eb94cbcbb28113b38e6b4a25075bc73e38c1f531cf95363598965efR1-R20) [[5]](diffhunk://#diff-3f9b89ba299a6e6fa67f6239ac692ed63a30522dd24733efa311d95d3da6bbddR1-R20) [[6]](diffhunk://#diff-fd1e601e2ccef50298b67c7279d9a2c7ac0d25915f0c64e7ec06ea3aa42cf9b4R1-R26) [[7]](diffhunk://#diff-23b7e87ee4097e7c933f08355750a7b3c92835630b5551592fc86ca7cc379a70R1-R16) [[8]](diffhunk://#diff-4db1dcda71276a6148b1b60e2e263224771f13a53b85bb1a8b8e0ad442d8a2d1R1-R16) [[9]](diffhunk://#diff-32ba477b9d4f32c3e281d766f14ce0c0b360eaa8376b79589763dbafba6a89ccR1-R8) [[10]](diffhunk://#diff-a854c06e21b8ddbe2e0e92f93944a702123d3135b5e5a58cfa6a5ed5495eebf4R1-R9)

**Dialog Enhancements:**

- Introduced Hlm-styled Dialog components and directives, including content, header, footer, overlay, title, description, and close button, with all exports and an import array in the main index. (`index.ts`, `hlm-dialog-content.ts`, `hlm-dialog-header.ts`, `hlm-dialog-footer.ts`, `hlm-dialog-overlay.ts`, `hlm-dialog-title.ts`, `hlm-dialog-description.ts`, `hlm-dialog-close.ts`) [[1]](diffhunk://#diff-acc586fc287e0e7d8c963ce5b31909d7777aa5bd6df79f859a206534c29cb37cR1-R29) [[2]](diffhunk://#diff-0975c6b861030c4466394f5f5f6bc681e8c9d9321a3821b0553e1710ad157e86R1-R50) [[3]](diffhunk://#diff-bbeffcd1273406718c0a9adc5d7cfdabb4584a5ce50f82de5d1cd0497258a164R1-R20) [[4]](diffhunk://#diff-946ba1a50d311c699fc3539e5df2401c73e4319208429172fe840826a2097777R1-R20) [[5]](diffhunk://#diff-1403636ef90b73201efdc25b8a757fa2dde0355f98fd1b75ad3dae51975145a2R1-R24) [[6]](diffhunk://#diff-893340a7611976651698e471e23fbc0aea346b45b176aa0e706b274edb1f5674R1-R16) [[7]](diffhunk://#diff-07795e260d3e400b47bba0130e8e794efd5019deba4e18eacf39a3b9974069bfR1-R16) [[8]](diffhunk://#diff-88200391a49c390112a37b68dc9486882293229b9b6e1b1e53d6b7b97b71ea2bR1-R20)

- Added a new `HlmDialogService` to simplify opening dialogs with custom components, templates, and classes, merging user options with sensible defaults and Helm-specific styles. (`hlm-dialog.service.ts`)

**Styling and Utility Improvements:**

- All new components and directives use a consistent approach for styling via a `userClass` input and computed class merging with Helm utility functions, making customization straightforward. (Multiple files: see above references)

These changes lay the foundation for a cohesive, themeable dialog system across the application, making it easier for developers to implement modals that match the design system.