### PR TITLE
CTFD-55 - Standardization of Target to spartan-NG

### DIFF
--- a/libs/ui/checkbox/src/index.ts
+++ b/libs/ui/checkbox/src/index.ts
@@ -1,0 +1,5 @@
+import { HlmCheckbox } from './lib/hlm-checkbox';
+
+export * from './lib/hlm-checkbox';
+
+export const HlmCheckboxImports = [HlmCheckbox] as const;

--- a/libs/ui/checkbox/src/lib/hlm-checkbox.ts
+++ b/libs/ui/checkbox/src/lib/hlm-checkbox.ts
@@ -1,0 +1,138 @@
+import type { BooleanInput } from '@angular/cdk/coercion';
+import {
+	booleanAttribute,
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	forwardRef,
+	input,
+	linkedSignal,
+	model,
+	output,
+} from '@angular/core';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck } from '@ng-icons/lucide';
+import { BrnCheckbox } from '@spartan-ng/brain/checkbox';
+import type { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+export const HLM_CHECKBOX_VALUE_ACCESSOR = {
+	provide: NG_VALUE_ACCESSOR,
+	useExisting: forwardRef(() => HlmCheckbox),
+	multi: true,
+};
+
+@Component({
+	selector: 'hlm-checkbox',
+	imports: [BrnCheckbox, NgIcon, HlmIcon],
+	providers: [HLM_CHECKBOX_VALUE_ACCESSOR],
+	viewProviders: [provideIcons({ lucideCheck })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'contents peer',
+		'data-slot': 'checkbox',
+		'[attr.id]': 'null',
+		'[attr.aria-label]': 'null',
+		'[attr.aria-labelledby]': 'null',
+		'[attr.aria-describedby]': 'null',
+		'[attr.data-disabled]': '_disabled() ? "" : null',
+	},
+	template: `
+		<brn-checkbox
+			[id]="id()"
+			[name]="name()"
+			[class]="_computedClass()"
+			[checked]="checked()"
+			[(indeterminate)]="indeterminate"
+			[disabled]="_disabled()"
+			[required]="required()"
+			[aria-label]="ariaLabel()"
+			[aria-labelledby]="ariaLabelledby()"
+			[aria-describedby]="ariaDescribedby()"
+			(checkedChange)="_handleChange($event)"
+			(touched)="_onTouched?.()"
+		>
+			@if (checked() || indeterminate()) {
+				<span class="flex items-center justify-center text-current transition-none">
+					<ng-icon hlm size="14px" name="lucideCheck" />
+				</span>
+			}
+		</brn-checkbox>
+	`,
+})
+export class HlmCheckbox implements ControlValueAccessor {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive peer size-4 shrink-0 cursor-default rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+			this.userClass(),
+			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
+		),
+	);
+
+	/** Used to set the id on the underlying brn element. */
+	public readonly id = input<string | null>(null);
+
+	/** Used to set the aria-label attribute on the underlying brn element. */
+	public readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });
+
+	/** Used to set the aria-labelledby attribute on the underlying brn element. */
+	public readonly ariaLabelledby = input<string | null>(null, { alias: 'aria-labelledby' });
+
+	/** Used to set the aria-describedby attribute on the underlying brn element. */
+	public readonly ariaDescribedby = input<string | null>(null, { alias: 'aria-describedby' });
+
+	/** The checked state of the checkbox. */
+	public readonly checked = model<boolean>(false);
+
+	/** Emits when checked state changes. */
+	public readonly checkedChange = output<boolean>();
+
+	/**
+	 * The indeterminate state of the checkbox.
+	 * For example, a "select all/deselect all" checkbox may be in the indeterminate state when some but not all of its sub-controls are checked.
+	 */
+	public readonly indeterminate = model<boolean>(false);
+
+	/** The name attribute of the checkbox. */
+	public readonly name = input<string | null>(null);
+
+	/** Whether the checkbox is required. */
+	public readonly required = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
+	/** Whether the checkbox is disabled. */
+	public readonly disabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
+	protected readonly _disabled = linkedSignal(this.disabled);
+
+	protected _onChange?: ChangeFn<boolean>;
+	protected _onTouched?: TouchFn;
+
+	protected _handleChange(value: boolean): void {
+		if (this._disabled()) return;
+		this.checked.set(value);
+		this.checkedChange.emit(value);
+		this._onChange?.(value);
+	}
+
+	/** CONTROL VALUE ACCESSOR */
+	writeValue(value: boolean): void {
+		this.checked.set(value);
+	}
+
+	registerOnChange(fn: ChangeFn<boolean>): void {
+		this._onChange = fn;
+	}
+
+	registerOnTouched(fn: TouchFn): void {
+		this._onTouched = fn;
+	}
+
+	setDisabledState(isDisabled: boolean): void {
+		this._disabled.set(isDisabled);
+	}
+}

--- a/libs/ui/dialog/src/index.ts
+++ b/libs/ui/dialog/src/index.ts
@@ -1,0 +1,32 @@
+import { HlmDialog } from './lib/hlm-dialog';
+import { HlmDialogClose } from './lib/hlm-dialog-close';
+import { HlmDialogContent } from './lib/hlm-dialog-content';
+import { HlmDialogDescription } from './lib/hlm-dialog-description';
+import { HlmDialogFooter } from './lib/hlm-dialog-footer';
+import { HlmDialogHeader } from './lib/hlm-dialog-header';
+import { HlmDialogOverlay } from './lib/hlm-dialog-overlay';
+import { HlmDialogTitle } from './lib/hlm-dialog-title';
+import { HlmDialogTrigger } from './lib/hlm-dialog-trigger';
+
+export * from './lib/hlm-dialog';
+export * from './lib/hlm-dialog-close';
+export * from './lib/hlm-dialog-content';
+export * from './lib/hlm-dialog-description';
+export * from './lib/hlm-dialog-footer';
+export * from './lib/hlm-dialog-header';
+export * from './lib/hlm-dialog-overlay';
+export * from './lib/hlm-dialog-title';
+export * from './lib/hlm-dialog-trigger';
+export * from './lib/hlm-dialog.service';
+
+export const HlmDialogImports = [
+	HlmDialog,
+	HlmDialogClose,
+	HlmDialogContent,
+	HlmDialogDescription,
+	HlmDialogFooter,
+	HlmDialogHeader,
+	HlmDialogOverlay,
+	HlmDialogTitle,
+	HlmDialogTrigger,
+] as const;

--- a/libs/ui/dialog/src/lib/hlm-dialog-close.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-close.ts
@@ -1,0 +1,19 @@
+import { Directive } from '@angular/core';
+import { BrnDialogClose } from '@spartan-ng/brain/dialog';
+import { classes } from '@ctfdeck/helm/utils';
+
+@Directive({
+	selector: 'button[hlmDialogClose]',
+	hostDirectives: [{ directive: BrnDialogClose, inputs: ['delay'] }],
+	host: {
+		'data-slot': 'dialog-close',
+	},
+})
+export class HlmDialogClose {
+	constructor() {
+		classes(
+			() =>
+				'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute end-4 top-4 flex items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none [&_ng-icon]:shrink-0',
+		);
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-content.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-content.ts
@@ -1,0 +1,52 @@
+import type { BooleanInput } from '@angular/cdk/coercion';
+import { NgComponentOutlet } from '@angular/common';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { provideIcons } from '@ng-icons/core';
+import { lucideX } from '@ng-icons/lucide';
+import { BrnDialogRef, injectBrnDialogContext } from '@spartan-ng/brain/dialog';
+import { HlmIconImports } from '@ctfdeck/helm/icon';
+import { classes } from '@ctfdeck/helm/utils';
+import { HlmDialogClose } from './hlm-dialog-close';
+
+@Component({
+	selector: 'hlm-dialog-content',
+	imports: [NgComponentOutlet, HlmDialogClose, HlmIconImports],
+	providers: [provideIcons({ lucideX })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'data-slot': 'dialog-content',
+		'[attr.data-state]': 'state()',
+	},
+	template: `
+		@if (component) {
+			<ng-container [ngComponentOutlet]="component" />
+		} @else {
+			<ng-content />
+		}
+
+		@if (showCloseButton()) {
+			<button hlmDialogClose>
+				<span class="sr-only">Close</span>
+				<ng-icon hlm size="sm" name="lucideX" />
+			</button>
+		}
+	`,
+})
+export class HlmDialogContent {
+	private readonly _dialogRef = inject(BrnDialogRef);
+	private readonly _dialogContext = injectBrnDialogContext({ optional: true });
+
+	public readonly showCloseButton = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
+
+	public readonly state = computed(() => this._dialogRef?.state() ?? 'closed');
+
+	public readonly component = this._dialogContext?.$component;
+	private readonly _dynamicComponentClass = this._dialogContext?.$dynamicComponentClass;
+
+	constructor() {
+		classes(() => [
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+			this._dynamicComponentClass,
+		]);
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-description.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-description.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { BrnDialogDescription } from '@spartan-ng/brain/dialog';
+import { classes } from '@ctfdeck/helm/utils';
+
+@Directive({
+	selector: '[hlmDialogDescription]',
+	hostDirectives: [BrnDialogDescription],
+	host: {
+		'data-slot': 'dialog-description',
+	},
+})
+export class HlmDialogDescription {
+	constructor() {
+		classes(() => 'text-muted-foreground text-sm');
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-footer.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-footer.ts
@@ -1,0 +1,14 @@
+import { Directive } from '@angular/core';
+import { classes } from '@ctfdeck/helm/utils';
+
+@Directive({
+	selector: '[hlmDialogFooter],hlm-dialog-footer',
+	host: {
+		'data-slot': 'dialog-footer',
+	},
+})
+export class HlmDialogFooter {
+	constructor() {
+		classes(() => 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end');
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-header.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-header.ts
@@ -1,0 +1,14 @@
+import { Directive } from '@angular/core';
+import { classes } from '@ctfdeck/helm/utils';
+
+@Directive({
+	selector: '[hlmDialogHeader],hlm-dialog-header',
+	host: {
+		'data-slot': 'dialog-header',
+	},
+})
+export class HlmDialogHeader {
+	constructor() {
+		classes(() => 'flex flex-col gap-2 text-center sm:text-start');
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-overlay.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-overlay.ts
@@ -1,0 +1,26 @@
+import { computed, Directive, effect, input, untracked } from '@angular/core';
+import { injectCustomClassSettable } from '@spartan-ng/brain/core';
+import { BrnDialogOverlay } from '@spartan-ng/brain/dialog';
+import { hlm } from '@ctfdeck/helm/utils';
+import { ClassValue } from 'clsx';
+
+export const hlmDialogOverlayClass =
+	'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-black/50';
+
+@Directive({
+	selector: '[hlmDialogOverlay],hlm-dialog-overlay',
+	hostDirectives: [BrnDialogOverlay],
+})
+export class HlmDialogOverlay {
+	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm(hlmDialogOverlayClass, this.userClass()));
+
+	constructor() {
+		effect(() => {
+			const newClass = this._computedClass();
+			untracked(() => this._classSettable?.setClassToCustomElement(newClass));
+		});
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-title.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-title.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { BrnDialogTitle } from '@spartan-ng/brain/dialog';
+import { classes } from '@ctfdeck/helm/utils';
+
+@Directive({
+	selector: '[hlmDialogTitle]',
+	hostDirectives: [BrnDialogTitle],
+	host: {
+		'data-slot': 'dialog-title',
+	},
+})
+export class HlmDialogTitle {
+	constructor() {
+		classes(() => 'text-lg leading-none font-semibold');
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog-trigger.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog-trigger.ts
@@ -1,0 +1,11 @@
+import { Directive } from '@angular/core';
+import { BrnDialogTrigger } from '@spartan-ng/brain/dialog';
+
+@Directive({
+	selector: 'button[hlmDialogTrigger],button[hlmDialogTriggerFor]',
+	hostDirectives: [{ directive: BrnDialogTrigger, inputs: ['id', 'brnDialogTriggerFor: hlmDialogTriggerFor', 'type'] }],
+	host: {
+		'data-slot': 'dialog-trigger',
+	},
+})
+export class HlmDialogTrigger {}

--- a/libs/ui/dialog/src/lib/hlm-dialog.service.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog.service.ts
@@ -1,0 +1,31 @@
+import type { ComponentType } from '@angular/cdk/portal';
+import { inject, Injectable, type TemplateRef } from '@angular/core';
+import { type BrnDialogOptions, BrnDialogService, cssClassesToArray } from '@spartan-ng/brain/dialog';
+import { HlmDialogContent } from './hlm-dialog-content';
+import { hlmDialogOverlayClass } from './hlm-dialog-overlay';
+
+export type HlmDialogOptions<DialogContext = unknown> = BrnDialogOptions & {
+	contentClass?: string;
+	context?: DialogContext;
+};
+
+@Injectable({
+	providedIn: 'root',
+})
+export class HlmDialogService {
+	private readonly _brnDialogService = inject(BrnDialogService);
+
+	public open(component: ComponentType<unknown> | TemplateRef<unknown>, options?: Partial<HlmDialogOptions>) {
+		const mergedOptions = {
+			...(options ?? {}),
+			backdropClass: cssClassesToArray(`${hlmDialogOverlayClass} ${options?.backdropClass ?? ''}`),
+			context: {
+				...(options?.context && typeof options.context === 'object' ? options.context : {}),
+				$component: component,
+				$dynamicComponentClass: options?.contentClass,
+			},
+		};
+
+		return this._brnDialogService.open(HlmDialogContent, undefined, mergedOptions.context, mergedOptions);
+	}
+}

--- a/libs/ui/dialog/src/lib/hlm-dialog.ts
+++ b/libs/ui/dialog/src/lib/hlm-dialog.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import { BrnDialog, provideBrnDialogDefaultOptions } from '@spartan-ng/brain/dialog';
+import { HlmDialogOverlay } from './hlm-dialog-overlay';
+
+@Component({
+	selector: 'hlm-dialog',
+	exportAs: 'hlmDialog',
+	imports: [HlmDialogOverlay],
+	providers: [
+		{
+			provide: BrnDialog,
+			useExisting: forwardRef(() => HlmDialog),
+		},
+		provideBrnDialogDefaultOptions({
+			// add custom options here
+		}),
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-dialog-overlay />
+		<ng-content />
+	`,
+})
+export class HlmDialog extends BrnDialog {}

--- a/libs/ui/label/src/index.ts
+++ b/libs/ui/label/src/index.ts
@@ -1,0 +1,5 @@
+import { HlmLabel } from './lib/hlm-label';
+
+export * from './lib/hlm-label';
+
+export const HlmLabelImports = [HlmLabel] as const;

--- a/libs/ui/label/src/lib/hlm-label.ts
+++ b/libs/ui/label/src/lib/hlm-label.ts
@@ -1,0 +1,27 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnLabel } from '@spartan-ng/brain/label';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmLabel]',
+	hostDirectives: [
+		{
+			directive: BrnLabel,
+			inputs: ['id'],
+		},
+	],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmLabel {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 peer-data-[disabled]:cursor-not-allowed peer-data-[disabled]:opacity-50 has-[[disabled]]:cursor-not-allowed has-[[disabled]]:opacity-50',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/sonner/src/index.ts
+++ b/libs/ui/sonner/src/index.ts
@@ -1,0 +1,5 @@
+import { HlmToaster } from './lib/hlm-toaster';
+
+export * from './lib/hlm-toaster';
+
+export const HlmToasterImports = [HlmToaster] as const;

--- a/libs/ui/sonner/src/lib/hlm-toaster.ts
+++ b/libs/ui/sonner/src/lib/hlm-toaster.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectionStrategy, Component, booleanAttribute, computed, input, numberAttribute } from '@angular/core';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+import { NgxSonnerToaster, type ToasterProps } from 'ngx-sonner';
+
+@Component({
+	selector: 'hlm-toaster',
+	imports: [NgxSonnerToaster],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<ngx-sonner-toaster
+			[class]="_computedClass()"
+			[invert]="invert()"
+			[theme]="theme()"
+			[position]="position()"
+			[hotKey]="hotKey()"
+			[richColors]="richColors()"
+			[expand]="expand()"
+			[duration]="duration()"
+			[visibleToasts]="visibleToasts()"
+			[closeButton]="closeButton()"
+			[toastOptions]="toastOptions()"
+			[offset]="offset()"
+			[dir]="dir()"
+			[style]="userStyle()"
+		/>
+	`,
+})
+export class HlmToaster {
+	public readonly invert = input<ToasterProps['invert'], boolean | string>(false, {
+		transform: booleanAttribute,
+	});
+	public readonly theme = input<ToasterProps['theme']>('light');
+	public readonly position = input<ToasterProps['position']>('bottom-right');
+	public readonly hotKey = input<ToasterProps['hotkey']>(['altKey', 'KeyT']);
+	public readonly richColors = input<ToasterProps['richColors'], boolean | string>(false, {
+		transform: booleanAttribute,
+	});
+	public readonly expand = input<ToasterProps['expand'], boolean | string>(false, {
+		transform: booleanAttribute,
+	});
+	public readonly duration = input<ToasterProps['duration'], number | string>(4000, {
+		transform: numberAttribute,
+	});
+	public readonly visibleToasts = input<ToasterProps['visibleToasts'], number | string>(3, {
+		transform: numberAttribute,
+	});
+	public readonly closeButton = input<ToasterProps['closeButton'], boolean | string>(false, {
+		transform: booleanAttribute,
+	});
+	public readonly toastOptions = input<ToasterProps['toastOptions']>({});
+	public readonly offset = input<ToasterProps['offset']>(null);
+	public readonly dir = input<ToasterProps['dir']>('auto');
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly userStyle = input<Record<string, string>>(
+		{
+			'--normal-bg': 'var(--popover)',
+			'--normal-text': 'var(--popover-foreground)',
+			'--normal-border': 'var(--border)',
+			'--border-radius': 'var(--radius)',
+		},
+		{ alias: 'style' },
+	);
+
+	protected readonly _computedClass = computed(() => hlm('toaster group', this.userClass()));
+}

--- a/libs/ui/tabs/src/index.ts
+++ b/libs/ui/tabs/src/index.ts
@@ -1,0 +1,13 @@
+import { HlmTabs } from './lib/hlm-tabs';
+import { HlmTabsContent } from './lib/hlm-tabs-content';
+import { HlmTabsList } from './lib/hlm-tabs-list';
+import { HlmTabsPaginatedList } from './lib/hlm-tabs-paginated-list';
+import { HlmTabsTrigger } from './lib/hlm-tabs-trigger';
+
+export * from './lib/hlm-tabs';
+export * from './lib/hlm-tabs-content';
+export * from './lib/hlm-tabs-list';
+export * from './lib/hlm-tabs-paginated-list';
+export * from './lib/hlm-tabs-trigger';
+
+export const HlmTabsImports = [HlmTabs, HlmTabsList, HlmTabsTrigger, HlmTabsContent, HlmTabsPaginatedList] as const;

--- a/libs/ui/tabs/src/lib/hlm-tabs-content.ts
+++ b/libs/ui/tabs/src/lib/hlm-tabs-content.ts
@@ -1,0 +1,23 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnTabsContent } from '@spartan-ng/brain/tabs';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmTabsContent]',
+	hostDirectives: [{ directive: BrnTabsContent, inputs: ['brnTabsContent: hlmTabsContent'] }],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmTabsContent {
+	public readonly contentFor = input.required<string>({ alias: 'hlmTabsContent' });
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'ring-offset-background focus-visible:ring-ring mt-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/tabs/src/lib/hlm-tabs-list.ts
+++ b/libs/ui/tabs/src/lib/hlm-tabs-list.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { BrnTabsList } from '@spartan-ng/brain/tabs';
+import { hlm } from '@ctfdeck/helm/utils';
+import { type VariantProps, cva } from 'class-variance-authority';
+import type { ClassValue } from 'clsx';
+
+export const listVariants = cva(
+	'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+	{
+		variants: {
+			orientation: {
+				horizontal: 'h-10 space-x-1',
+				vertical: 'mt-2 h-fit flex-col space-y-1',
+			},
+		},
+		defaultVariants: {
+			orientation: 'horizontal',
+		},
+	},
+);
+type ListVariants = VariantProps<typeof listVariants>;
+
+@Component({
+	selector: 'hlm-tabs-list',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	hostDirectives: [BrnTabsList],
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: '<ng-content/>',
+})
+export class HlmTabsList {
+	public readonly orientation = input<ListVariants['orientation']>('horizontal');
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(listVariants({ orientation: this.orientation() }), this.userClass()),
+	);
+}

--- a/libs/ui/tabs/src/lib/hlm-tabs-paginated-list.ts
+++ b/libs/ui/tabs/src/lib/hlm-tabs-paginated-list.ts
@@ -1,0 +1,105 @@
+import { CdkObserveContent } from '@angular/cdk/observers';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	type ElementRef,
+	computed,
+	contentChildren,
+	input,
+	viewChild,
+} from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronLeft, lucideChevronRight } from '@ng-icons/lucide';
+import { type BrnPaginatedTabHeaderItem, BrnTabsPaginatedList, BrnTabsTrigger } from '@spartan-ng/brain/tabs';
+import { buttonVariants } from '@ctfdeck/helm/button';
+import { HlmIcon } from '@ctfdeck/helm/icon';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+import type { Observable } from 'rxjs';
+import { listVariants } from './hlm-tabs-list';
+
+@Component({
+	selector: 'hlm-paginated-tabs-list',
+	imports: [CdkObserveContent, NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideChevronRight, lucideChevronLeft })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: `
+		<button
+			#previousPaginator
+			data-pagination="previous"
+			type="button"
+			aria-hidden="true"
+			tabindex="-1"
+			[class.flex]="showPaginationControls()"
+			[class.hidden]="!showPaginationControls()"
+			[class]="_paginationButtonClass()"
+			[disabled]="disableScrollBefore || null"
+			(click)="_handlePaginatorClick('before')"
+			(mousedown)="_handlePaginatorPress('before', $event)"
+			(touchend)="_stopInterval()"
+		>
+			<ng-icon hlm size="base" name="lucideChevronLeft" />
+		</button>
+
+		<div #tabListContainer class="z-[1] flex grow overflow-hidden" (keydown)="_handleKeydown($event)">
+			<div class="relative grow transition-transform" #tabList role="tablist" (cdkObserveContent)="_onContentChanges()">
+				<div #tabListInner [class]="_tabListClass()">
+					<ng-content></ng-content>
+				</div>
+			</div>
+		</div>
+
+		<button
+			#nextPaginator
+			data-pagination="next"
+			type="button"
+			aria-hidden="true"
+			tabindex="-1"
+			[class.flex]="showPaginationControls()"
+			[class.hidden]="!showPaginationControls()"
+			[class]="_paginationButtonClass()"
+			[disabled]="disableScrollAfter || null"
+			(click)="_handlePaginatorClick('after')"
+			(mousedown)="_handlePaginatorPress('after', $event)"
+			(touchend)="_stopInterval()"
+		>
+			<ng-icon hlm size="base" name="lucideChevronRight" />
+		</button>
+	`,
+})
+export class HlmTabsPaginatedList extends BrnTabsPaginatedList {
+	public readonly items = contentChildren(BrnTabsTrigger, { descendants: false });
+	/** Explicitly annotating type to avoid non-portable inferred type */
+	public readonly itemsChanges: Observable<ReadonlyArray<BrnPaginatedTabHeaderItem>> = toObservable(this.items);
+
+	public readonly tabListContainer = viewChild.required<ElementRef<HTMLElement>>('tabListContainer');
+	public readonly tabList = viewChild.required<ElementRef<HTMLElement>>('tabList');
+	public readonly tabListInner = viewChild.required<ElementRef<HTMLElement>>('tabListInner');
+	public readonly nextPaginator = viewChild.required<ElementRef<HTMLElement>>('nextPaginator');
+	public readonly previousPaginator = viewChild.required<ElementRef<HTMLElement>>('previousPaginator');
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('relative flex flex-shrink-0 gap-1 overflow-hidden', this.userClass()),
+	);
+
+	public readonly tabListClass = input<ClassValue>('', { alias: 'tabListClass' });
+	protected readonly _tabListClass = computed(() => hlm(listVariants(), this.tabListClass()));
+
+	public readonly paginationButtonClass = input<ClassValue>('', { alias: 'paginationButtonClass' });
+	protected readonly _paginationButtonClass = computed(() =>
+		hlm(
+			'relative z-[2] select-none disabled:cursor-default',
+			buttonVariants({ variant: 'ghost', size: 'icon' }),
+			this.paginationButtonClass(),
+		),
+	);
+
+	protected _itemSelected(event: KeyboardEvent) {
+		event.preventDefault();
+	}
+}

--- a/libs/ui/tabs/src/lib/hlm-tabs-trigger.ts
+++ b/libs/ui/tabs/src/lib/hlm-tabs-trigger.ts
@@ -1,0 +1,22 @@
+import { Directive, computed, input } from '@angular/core';
+import { BrnTabsTrigger } from '@spartan-ng/brain/tabs';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Directive({
+	selector: '[hlmTabsTrigger]',
+	hostDirectives: [{ directive: BrnTabsTrigger, inputs: ['brnTabsTrigger: hlmTabsTrigger', 'disabled'] }],
+	host: {
+		'[class]': '_computedClass()',
+	},
+})
+export class HlmTabsTrigger {
+	public readonly triggerFor = input.required<string>({ alias: 'hlmTabsTrigger' });
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0 [&_ng-icon]:text-base',
+			this.userClass(),
+		),
+	);
+}

--- a/libs/ui/tabs/src/lib/hlm-tabs.ts
+++ b/libs/ui/tabs/src/lib/hlm-tabs.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { BrnTabs } from '@spartan-ng/brain/tabs';
+import { hlm } from '@ctfdeck/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'hlm-tabs',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	hostDirectives: [
+		{
+			directive: BrnTabs,
+			inputs: ['orientation', 'direction', 'activationMode', 'brnTabs: tab'],
+			outputs: ['tabActivated'],
+		},
+	],
+	host: {
+		'[class]': '_computedClass()',
+	},
+	template: '<ng-content/>',
+})
+export class HlmTabs {
+	public readonly tab = input.required<string>();
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() => hlm('flex flex-col gap-2', this.userClass()));
+}

--- a/libs/ui/utils/src/index.ts
+++ b/libs/ui/utils/src/index.ts
@@ -1,1 +1,8 @@
-export * from './lib/hlm';
+import { ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function hlm(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const classes = hlm;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "ansi-to-html": "^0.7.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "lucide-angular": "^0.563.0",
+        "ngx-sonner": ">=3.0.0",
         "rxjs": "~7.8.0",
         "tailwind-merge": "^3.3.1",
         "tslib": "^2.3.0"
@@ -20369,6 +20371,19 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-angular": {
+      "version": "0.563.0",
+      "resolved": "https://registry.npmjs.org/lucide-angular/-/lucide-angular-0.563.0.tgz",
+      "integrity": "sha512-1zqu3beQeRTkTSd+o2gg5oip60iEsi3MyDFvenYelAZ1Y7ptH1d11+ft1QQy8HzoGgtV2twqlsmgfHIgNSWUjQ==",
+      "license": "ISC",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "13.x - 21.x",
+        "@angular/core": "13.x - 21.x"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -21023,6 +21038,19 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ngx-sonner": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-sonner/-/ngx-sonner-3.1.0.tgz",
+      "integrity": "sha512-hN5GolhBeVs0gzPNZi2VPnbv/sM+3+aMGCvIjH33MC8LHz+QIiOUWGw3AbnCH/hQxy08AGwkWHVYy1acvXByQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.85.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "ansi-to-html": "^0.7.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "lucide-angular": "^0.563.0",
+    "ngx-sonner": ">=3.0.0",
     "rxjs": "~7.8.0",
     "tailwind-merge": "^3.3.1",
     "tslib": "^2.3.0"

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,5 +1,4 @@
 <div class="app-root flex flex-col h-screen">
-  <!-- Menubar -->
   <spartan-menubar
     (openTargetManagerEvent)="openTargetManager($event)"
   ></spartan-menubar>
@@ -14,21 +13,21 @@
     </main>
   </div>
 
-  <!-- Modal Target Manager -->
   <div 
     *ngIf="targetManagerVisible" 
-    class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+    class="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
     (click)="closeTargetManager()"
   >
     <div 
-      class="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-auto m-4"
+      class="bg-slate-900 border border-border rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
       (click)="$event.stopPropagation()"
     >
       <app-target-manager 
-        #targetManager
         [mode]="targetManagerMode"
         (closeEvent)="closeTargetManager()"
       ></app-target-manager>
     </div>
   </div>
+
+  <hlm-toaster />
 </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,11 +4,19 @@ import { CommonModule } from '@angular/common';
 import { Menubar } from '../ui/menubar/menubar';
 import { ChatSidebar } from '../ui/sidebar/chat-sidebar';
 import { TargetManagerComponent } from '../ui/target-manager/target-manager.component';
+import { HlmToaster } from '@ctfdeck/helm/sonner';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CommonModule, RouterOutlet, Menubar, ChatSidebar, TargetManagerComponent],
+  imports: [
+    CommonModule, 
+    RouterOutlet, 
+    Menubar, 
+    ChatSidebar, 
+    TargetManagerComponent,
+    HlmToaster
+  ],
   templateUrl: './app.html',
   styleUrls: ['./app.css'],
 })

--- a/src/ui/menubar/menubar.html
+++ b/src/ui/menubar/menubar.html
@@ -20,9 +20,8 @@
     <hlm-menu variant="menubar" class="w-56">
       <hlm-menu-group>
         <button hlmMenuItem (click)="openTargetManager('view')">Configuration</button>
-        <button hlmMenuItem (click)="openTargetManager('add')">Ajout d'une cible</button>
-        <button hlmMenuItem (click)="openTargetManager('delete')">Retrait d'une cible</button>
-        <button hlmMenuItem (click)="saveTargets()">Sauvegarde d'une cible</button>
+        <button hlmMenuItem (click)="openTargetManager('add')">Adding a target</button>
+        <button hlmMenuItem (click)="openTargetManager('delete')">Target removal</button>
       </hlm-menu-group>
     </hlm-menu>
   </ng-template>
@@ -45,9 +44,7 @@
           <hlm-menu-item-sub-indicator />
         </button>
       </hlm-menu-group>
-
       <hlm-menu-separator />
-
       <hlm-menu-group>
         <button hlmMenuItem (click)="openExternal('https://cve.org')">CVE.org</button>
         <button hlmMenuItem (click)="openExternal('https://www.exploit-db.com')">ExploitDB</button>

--- a/src/ui/target-manager/target-manager.component.ts
+++ b/src/ui/target-manager/target-manager.component.ts
@@ -3,360 +3,175 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TargetService, Target } from '../../app/core/services/target.service';
 
+import { BrnTabsImports } from '@spartan-ng/brain/tabs';
+import { HlmTabsImports } from '@ctfdeck/helm/tabs';
+import { HlmButtonImports } from '@ctfdeck/helm/button';
+import { HlmInputImports } from '@ctfdeck/helm/input';
+import { HlmLabelImports } from '@ctfdeck/helm/label';
+
+import { HlmIcon } from '../../../libs/ui/icon/src/lib/hlm-icon'; 
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideTarget } from '@ng-icons/lucide';
+
+import { toast } from 'ngx-sonner';
+
 @Component({
   selector: 'app-target-manager',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule, 
+    FormsModule,
+    BrnTabsImports,
+    HlmTabsImports,
+    HlmButtonImports,
+    HlmInputImports,
+    HlmLabelImports,
+    NgIcon,
+    HlmIcon
+  ],
+  providers: [
+    provideIcons({ lucideTarget })
+  ],
   template: `
-    <div class="target-manager p-6">
-      <!-- Header -->
-      <div class="flex justify-between items-center mb-6 border-b pb-4">
-        <h2 class="text-2xl font-bold">
-          {{ mode === 'view' ? '📋 Configuration des cibles' : 
-             mode === 'add' ? '➕ Ajouter une cible' : 
-             '🗑️ Supprimer des cibles' }}
-        </h2>
-        <button 
-          (click)="close()" 
-          class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-2xl font-bold"
-          aria-label="Fermer"
-        >
-          ×
-        </button>
+    <div class="p-8 bg-background text-foreground">
+      <div class="mb-8 flex items-center gap-3">
+        <ng-icon hlm name="lucideTarget" size="lg" class="text-primary" />
+        
+        <div>
+          <h3 class="text-2xl font-semibold tracking-tight">Target Management</h3>
+          <p class="text-sm text-muted-foreground">Configure and oversee your network targets.</p>
+        </div>
       </div>
-      
-      <!-- Contenu selon le mode -->
-      <div [ngSwitch]="mode" class="min-h-[300px]">
-        
-        <!-- MODE VIEW/EDIT -->
-        <div *ngSwitchCase="'view'" class="space-y-4">
-          <div *ngIf="targets.length === 0" class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded text-center">
-            <p class="text-gray-600 dark:text-gray-400">Aucune cible configurée.</p>
-            <button 
-              (click)="switchMode('add')"
-              class="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            >
-              Ajouter votre première cible
-            </button>
+
+      <hlm-tabs [tab]="mode" class="w-full">
+        <hlm-tabs-list class="grid w-full grid-cols-3 mb-6">
+          <button hlmTabsTrigger="view" (click)="mode = 'view'">Configuration</button>
+          <button hlmTabsTrigger="add" (click)="mode = 'add'">Add Target</button>
+          <button hlmTabsTrigger="delete" (click)="mode = 'delete'">Bulk Delete</button>
+        </hlm-tabs-list>
+
+        <div hlmTabsContent="view" class="space-y-4 max-h-[450px] overflow-y-auto pr-2 custom-scrollbar">
+          <div *ngIf="targets.length === 0" class="flex flex-col items-center justify-center py-12 border-2 border-dashed rounded-xl border-border bg-card/30">
+            <p class="text-muted-foreground font-medium">No targets configured.</p>
           </div>
 
-          <div *ngIf="targets.length > 0" class="space-y-3">
-            <div 
-              *ngFor="let target of targets" 
-              class="bg-white dark:bg-slate-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 hover:shadow-md transition"
-            >
-              <div *ngIf="editingId !== target.id" class="flex justify-between items-start">
-                <div class="flex-1">
-                  <h4 class="font-semibold text-lg">{{ target.name }}</h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    🎯 {{ target.host }}{{ target.port ? ':' + target.port : '' }}
-                  </p>
-                  <p *ngIf="target.description" class="text-sm text-gray-500 mt-1">
-                    {{ target.description }}
-                  </p>
-                  <p class="text-xs text-gray-400 mt-2">
-                    Créé le {{ target.createdAt | date:'short' }}
-                  </p>
-                </div>
-                <div class="flex gap-2">
-                  <button 
-                    (click)="startEditing(target)"
-                    class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm"
-                  >
-                    ✏️ Éditer
-                  </button>
-                  <button 
-                    (click)="deleteOneTarget(target.id)"
-                    class="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm"
-                  >
-                    🗑️
-                  </button>
+          <div *ngFor="let target of targets" class="group relative flex flex-col gap-2 p-4 rounded-xl border border-border bg-card hover:bg-accent/50 transition-all">
+            <div *ngIf="editingId !== target.id" class="flex justify-between items-start">
+              <div class="space-y-1">
+                <h4 class="font-bold uppercase tracking-wider text-primary">{{ target.name }}</h4>
+                <div class="flex items-center gap-2">
+                    <code class="px-2 py-0.5 rounded bg-muted text-xs font-mono border border-border">
+                        {{ target.host }}{{ target.port ? ':' + target.port : '' }}
+                    </code>
                 </div>
               </div>
+              <div class="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button hlmBtn size="sm" variant="outline" (click)="startEditing(target)">Edit</button>
+                <button hlmBtn size="sm" variant="destructive" (click)="deleteOneTarget(target.id)">Delete</button>
+              </div>
+            </div>
 
-              <!-- Formulaire d'édition inline -->
-              <div *ngIf="editingId === target.id" class="space-y-3">
-                <input 
-                  [(ngModel)]="editForm.name"
-                  placeholder="Nom de la cible"
-                  class="w-full px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-                />
-                <div class="flex gap-2">
-                  <input 
-                    [(ngModel)]="editForm.host"
-                    placeholder="Host (IP/domain)"
-                    class="flex-1 px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-                  />
-                  <input 
-                    [(ngModel)]="editForm.port"
-                    type="number"
-                    placeholder="Port"
-                    class="w-24 px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-                  />
-                </div>
-                <textarea 
-                  [(ngModel)]="editForm.description"
-                  placeholder="Description (optionnel)"
-                  rows="2"
-                  class="w-full px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-                ></textarea>
-                <div class="flex gap-2">
-                  <button 
-                    (click)="saveEdit()"
-                    class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                  >
-                    💾 Sauvegarder
-                  </button>
-                  <button 
-                    (click)="cancelEdit()"
-                    class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400"
-                  >
-                    Annuler
-                  </button>
-                </div>
+            <div *ngIf="editingId === target.id" class="space-y-3 p-2 animate-in fade-in slide-in-from-top-1">
+              <input hlmInput [(ngModel)]="editForm.name" placeholder="Server name" class="w-full" />
+              <div class="flex gap-2">
+                <input hlmInput [(ngModel)]="editForm.host" placeholder="IP / Host" class="flex-1" />
+                <button hlmBtn size="sm" (click)="saveEdit()">Save</button>
+                <button hlmBtn size="sm" variant="ghost" (click)="editingId = null">Cancel</button>
               </div>
             </div>
           </div>
         </div>
-        
-        <!-- MODE ADD -->
-        <div *ngSwitchCase="'add'" class="space-y-4">
-          <form (ngSubmit)="addTarget()" class="space-y-4">
-            <div>
-              <label class="block text-sm font-medium mb-1">Nom de la cible *</label>
-              <input 
-                [(ngModel)]="addForm.name"
-                name="name"
-                type="text" 
-                required
-                placeholder="Ex: Serveur Web Production"
-                class="w-full px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-              />
-            </div>
 
+        <div hlmTabsContent="add" class="space-y-6 pt-2 animate-in fade-in duration-300">
+          <div class="space-y-4">
+            <div class="grid gap-2">
+              <label hlmLabel for="add-name">Resource Name</label>
+              <input hlmInput id="add-name" [(ngModel)]="addForm.name" placeholder="e.g., PROD-DB-01" />
+            </div>
             <div class="grid grid-cols-3 gap-4">
-              <div class="col-span-2">
-                <label class="block text-sm font-medium mb-1">Host (IP ou domaine) *</label>
-                <input 
-                  [(ngModel)]="addForm.host"
-                  name="host"
-                  type="text" 
-                  required
-                  placeholder="Ex: 192.168.1.100 ou example.com"
-                  class="w-full px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-                />
+              <div class="col-span-2 grid gap-2">
+                <label hlmLabel for="add-host">IP Address or Hostname</label>
+                <input hlmInput id="add-host" [(ngModel)]="addForm.host" placeholder="10.0.0.5" />
               </div>
-              <div>
-                <label class="block text-sm font-medium mb-1">Port</label>
-                <input 
-                  [(ngModel)]="addForm.port"
-                  name="port"
-                  type="number" 
-                  placeholder="80"
-                  class="w-full px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium mb-1">Description</label>
-              <textarea 
-                [(ngModel)]="addForm.description"
-                name="description"
-                rows="3"
-                placeholder="Notes supplémentaires sur cette cible..."
-                class="w-full px-3 py-2 border rounded dark:bg-slate-700 dark:border-gray-600"
-              ></textarea>
-            </div>
-
-            <div *ngIf="errorMessage" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded">
-              {{ errorMessage }}
-            </div>
-
-            <div class="flex justify-end gap-3 pt-4">
-              <button 
-                type="button"
-                (click)="close()" 
-                class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400"
-              >
-                Annuler
-              </button>
-              <button 
-                type="submit"
-                class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-              >
-                ➕ Ajouter la cible
-              </button>
-            </div>
-          </form>
-        </div>
-        
-        <!-- MODE DELETE -->
-        <div *ngSwitchCase="'delete'" class="space-y-4">
-          <div *ngIf="targets.length === 0" class="bg-red-50 dark:bg-red-900/20 p-6 rounded text-center">
-            <p class="text-gray-600 dark:text-gray-400">Aucune cible à supprimer.</p>
-          </div>
-
-          <div *ngIf="targets.length > 0" class="space-y-3">
-            <p class="text-sm text-gray-600 dark:text-gray-400">
-              Sélectionnez les cibles à supprimer :
-            </p>
-            
-            <div 
-              *ngFor="let target of targets" 
-              class="bg-white dark:bg-slate-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 hover:bg-gray-50 dark:hover:bg-slate-700 transition cursor-pointer"
-              (click)="toggleSelection(target.id)"
-            >
-              <label class="flex items-start gap-3 cursor-pointer">
-                <input 
-                  type="checkbox" 
-                  [checked]="selectedIds.has(target.id)"
-                  (click)="$event.stopPropagation()"
-                  (change)="toggleSelection(target.id)"
-                  class="mt-1"
-                />
-                <div class="flex-1">
-                  <h4 class="font-semibold">{{ target.name }}</h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    {{ target.host }}{{ target.port ? ':' + target.port : '' }}
-                  </p>
-                </div>
-              </label>
-            </div>
-
-            <div class="flex justify-between items-center pt-4 border-t">
-              <p class="text-sm text-gray-600 dark:text-gray-400">
-                {{ selectedIds.size }} cible(s) sélectionnée(s)
-              </p>
-              <div class="flex gap-3">
-                <button 
-                  (click)="close()" 
-                  class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400"
-                >
-                  Annuler
-                </button>
-                <button 
-                  (click)="deleteSelected()"
-                  [disabled]="selectedIds.size === 0"
-                  [class.opacity-50]="selectedIds.size === 0"
-                  [class.cursor-not-allowed]="selectedIds.size === 0"
-                  class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:hover:bg-red-600"
-                >
-                  🗑️ Supprimer ({{ selectedIds.size }})
-                </button>
+              <div class="grid gap-2">
+                <label hlmLabel for="add-port">Port</label>
+                <input hlmInput id="add-port" type="number" [(ngModel)]="addForm.port" placeholder="80" />
               </div>
             </div>
           </div>
+          <button hlmBtn class="w-full h-11" (click)="addTarget()">Add to List</button>
         </div>
+
+        <div hlmTabsContent="delete" class="space-y-4 pt-2">
+          <div class="rounded-md border border-border overflow-hidden">
+            <div *ngFor="let target of targets" 
+                 (click)="toggleSelection(target.id)" 
+                 [class.bg-accent]="selectedIds.has(target.id)"
+                 class="flex items-center gap-3 p-4 border-b border-border last:border-0 cursor-pointer hover:bg-accent/50 transition-colors">
+              <div class="h-4 w-4 rounded border border-primary flex items-center justify-center" 
+                   [class.bg-primary]="selectedIds.has(target.id)">
+                <div *ngIf="selectedIds.has(target.id)" class="text-[10px] text-primary-foreground">✔</div>
+              </div>
+              <span class="font-medium">{{ target.name }}</span>
+              <span class="text-xs text-muted-foreground ml-auto font-mono">{{ target.host }}</span>
+            </div>
+          </div>
+          <button hlmBtn variant="destructive" class="w-full" 
+                  [disabled]="selectedIds.size === 0" (click)="deleteSelected()">
+            Delete Selection ({{ selectedIds.size }})
+          </button>
+        </div>
+      </hlm-tabs>
+
+      <div class="mt-10 pt-4 border-t border-border flex justify-end">
+        <button hlmBtn variant="secondary" (click)="closeEvent.emit()">Close Manager</button>
       </div>
     </div>
-  `,
-  styles: [`
-    :host {
-      display: block;
-    }
-  `]
+  `
 })
 export class TargetManagerComponent implements OnInit {
   private targetService = inject(TargetService);
-
   @Input() mode: 'view' | 'add' | 'delete' = 'view';
   @Output() closeEvent = new EventEmitter<void>();
 
   targets: Target[] = [];
   selectedIds = new Set<string>();
-  errorMessage = '';
-
-  addForm = {
-    name: '',
-    host: '',
-    port: undefined as number | undefined,
-    description: ''
-  };
-
   editingId: string | null = null;
-  editForm = {
-    name: '',
-    host: '',
-    port: undefined as number | undefined,
-    description: ''
-  };
+  addForm = { name: '', host: '', port: undefined as number | undefined, description: '' };
+  editForm = { name: '', host: '', port: undefined as number | undefined, description: '' };
 
-  ngOnInit() {
-    this.loadTargets();
-  }
+  ngOnInit() { this.loadTargets(); }
+  loadTargets() { this.targets = this.targetService.getTargets(); }
 
-  loadTargets() {
-    this.targets = this.targetService.getTargets();
-  }
-
-  open(mode: 'view' | 'add' | 'delete') {
+  public open(mode: 'view' | 'add' | 'delete') {
     this.mode = mode;
     this.loadTargets();
-    this.resetForms();
   }
 
-  switchMode(mode: 'view' | 'add' | 'delete') {
-    this.mode = mode;
-    this.resetForms();
-  }
-
-  // ADD
   addTarget() {
-    this.errorMessage = '';
-
-    if (!this.addForm.name.trim() || !this.addForm.host.trim()) {
-      this.errorMessage = 'Le nom et le host sont obligatoires';
+    if (!this.addForm.name) {
+      toast.error('Error', { description: 'Target name is required.' });
       return;
     }
-
-    try {
-      this.targetService.addTarget({
-        name: this.addForm.name.trim(),
-        host: this.addForm.host.trim(),
-        port: this.addForm.port,
-        description: this.addForm.description.trim() || undefined
-      });
-
-      this.resetForms();
-      this.loadTargets();
-      this.mode = 'view';
-    } catch (error) {
-      this.errorMessage = 'Erreur lors de l\'ajout de la cible';
-      console.error(error);
-    }
+    this.targetService.addTarget({...this.addForm});
+    this.addForm = { name: '', host: '', port: undefined, description: '' };
+    this.loadTargets();
+    this.mode = 'view';
+    toast.success('Target added!', { description: 'Target successfully saved.' });
   }
 
-  // EDIT
   startEditing(target: Target) {
     this.editingId = target.id;
-    this.editForm = {
-      name: target.name,
-      host: target.host,
-      port: target.port,
-      description: target.description || ''
-    };
+    this.editForm = { name: target.name, host: target.host, port: target.port, description: target.description || '' };
   }
 
   saveEdit() {
-    if (!this.editingId) return;
-
-    const success = this.targetService.updateTarget(this.editingId, {
-      name: this.editForm.name.trim(),
-      host: this.editForm.host.trim(),
-      port: this.editForm.port,
-      description: this.editForm.description.trim() || undefined
-    });
-
-    if (success) {
+    if (this.editingId) {
+      this.targetService.updateTarget(this.editingId, this.editForm);
+      this.editingId = null;
       this.loadTargets();
-      this.cancelEdit();
+      toast.success('Changes saved', { description: 'Target updated.' });
     }
-  }
-
-  cancelEdit() {
-    this.editingId = null;
-    this.editForm = { name: '', host: '', port: undefined, description: '' };
   }
 
   toggleSelection(id: string) {
@@ -368,32 +183,17 @@ export class TargetManagerComponent implements OnInit {
   }
 
   deleteOneTarget(id: string) {
-    if (confirm('Êtes-vous sûr de vouloir supprimer cette cible ?')) {
-      this.targetService.deleteTarget(id);
-      this.loadTargets();
-    }
+    this.targetService.deleteTarget(id);
+    this.loadTargets();
+    toast.success('Target deleted', { description: 'Removed from configuration.' });
   }
 
   deleteSelected() {
-    if (this.selectedIds.size === 0) return;
-
-    if (confirm(`Supprimer ${this.selectedIds.size} cible(s) ?`)) {
+    const count = this.selectedIds.size;
+    if (count === 0) return;
       this.targetService.deleteTargets(Array.from(this.selectedIds));
       this.selectedIds.clear();
       this.loadTargets();
-    }
-  }
-
-  resetForms() {
-    this.addForm = { name: '', host: '', port: undefined, description: '' };
-    this.editForm = { name: '', host: '', port: undefined, description: '' };
-    this.editingId = null;
-    this.selectedIds.clear();
-    this.errorMessage = '';
-  }
-
-  close() {
-    this.resetForms();
-    this.closeEvent.emit();
+      toast.error('Deletion successful', { description: `${count} targets removed.`, closeButton: true });
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,18 @@
       ],
       "@ctfdeck/helm/textarea": [
         "./libs/ui/textarea/src/index.ts"
+      ],
+      "@ctfdeck/helm/dialog": [
+        "./libs/ui/dialog/src/index.ts"
+      ],
+      "@ctfdeck/helm/label": [
+        "./libs/ui/label/src/index.ts"
+      ],
+      "@ctfdeck/helm/tabs": [
+        "./libs/ui/tabs/src/index.ts"
+      ],
+      "@ctfdeck/helm/sonner": [
+        "./libs/ui/sonner/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
<img width="936" height="629" alt="Capture d&#39;écran 2026-02-03 191653" src="https://github.com/user-attachments/assets/ab6afe32-49e1-47af-88c8-487f5063a9af" />

Description
This PR refactors the Target Manager component to align with the project's design system by migrating it to Spartan-ng components.

Key Changes:
Spartan Integration: Replaced custom UI elements with hlm-tabs, hlm-button, hlm-input, and hlm-label.

Code Cleanup: Fixed module export issues and ensured standalone imports are correctly defined.

Consistency: Updated the targeting interface to match the global Spartan-based UI/UX of the application.