### PR TITLE
CTFD-101 - Handling signals front

### DIFF
--- a/src/app/domains/command-runner/models/runner-job.model.ts
+++ b/src/app/domains/command-runner/models/runner-job.model.ts
@@ -11,5 +11,6 @@ export interface RunnerJob {
   exitCode?: number;
   startedAt: Date;
   endedAt?: Date;
+  wsMessageId?: string;
 }
  

--- a/src/app/domains/command-runner/ui/command-runner.component.ts
+++ b/src/app/domains/command-runner/ui/command-runner.component.ts
@@ -368,7 +368,7 @@ export class CommandRunnerComponent implements OnInit, OnDestroy, OnChanges {
           errorBuffer += error;
         },
       )
-      .then(() => {
+      .promise.then(() => {
         this.isHelpRunning = false;
         this.renderHelpOutput(outputBuffer || errorBuffer);
         this.cdr.detectChanges();

--- a/src/app/domains/command-runner/ui/runner-jobs-modal.component.html
+++ b/src/app/domains/command-runner/ui/runner-jobs-modal.component.html
@@ -100,21 +100,32 @@
                   ← {{ 'runner.jobs.back' | translate }}
                 </button>
 
-                <div class="flex items-center gap-2 min-w-0 flex-1">
-                  <ng-icon
-                    hlm
-                    [name]="statusIcon(selectedJob.status)"
-                    [class]="statusClass(selectedJob.status) + ' shrink-0'"
-                    size="sm"
-                  />
-                  <code class="text-xs font-mono text-foreground truncate flex-1">
-                    {{ selectedJob.command }}
-                  </code>
-                  @if (selectedJob.exitCode !== undefined) {
-                    <span class="text-xs text-muted-foreground shrink-0">
-                      {{ 'runner.jobs.exit' | translate }} {{ selectedJob.exitCode }}
-                    </span>
-                  }
+                <div class="flex items-center gap-4 min-w-0 flex-1">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <ng-icon
+                      hlm
+                      [name]="statusIcon(selectedJob.status)"
+                      [class]="statusClass(selectedJob.status) + ' shrink-0'"
+                      size="sm"
+                    />
+                    <span class="text-sm font-semibold truncate max-w-[200px]">{{ selectedJob.label }}</span>
+                  </div>
+
+                  <div class="hidden md:flex items-center gap-3 text-[10px] text-muted-foreground border-l border-border pl-4">
+                    <div class="flex items-center gap-1">
+                      <ng-icon hlm name="lucideClock" size="xs" />
+                      {{ selectedJob.startedAt | date:'HH:mm:ss' }}
+                    </div>
+                    @if (selectedJob.status !== 'running') {
+                      <span>•</span>
+                      <span>{{ duration(selectedJob) }}</span>
+                    }
+                    @if (selectedJob.exitCode !== undefined) {
+                      <span class="px-1.5 py-0.5 rounded bg-muted border border-border">
+                        {{ 'runner.jobs.exit' | translate }} {{ selectedJob.exitCode }}
+                      </span>
+                    }
+                  </div>
                 </div>
 
                 <div class="flex items-center gap-1 shrink-0">
@@ -127,6 +138,12 @@
                   }
 
                   @if (selectedJob.status !== 'running') {
+                    <button hlmBtn size="sm" variant="outline" class="h-7 px-2 text-xs gap-1"
+                      (click)="restartJob(selectedJob.id)">
+                      <ng-icon hlm name="lucideRotateCw" size="xs" />
+                      <span class="hidden sm:inline">{{ 'runner.run.restart' | translate }}</span>
+                    </button>
+
                     <button hlmBtn size="icon" variant="ghost"
                       class="h-7 w-7"
                       [title]="'runner.jobs.remove' | translate"

--- a/src/app/domains/command-runner/ui/runner-jobs-modal.component.ts
+++ b/src/app/domains/command-runner/ui/runner-jobs-modal.component.ts
@@ -26,6 +26,7 @@ import {
   lucideX,
   lucideLoader,
   lucideTerminal,
+  lucideRotateCw,
 } from '@ng-icons/lucide';
 import { HlmButtonImports } from '@ctfdeck/helm/button';
 import { HlmIconImports } from '@ctfdeck/helm/icon';
@@ -47,6 +48,7 @@ import { TranslatePipe } from '../../../shell/menubar/translate.pipe';
       lucideX,
       lucideLoader,
       lucideTerminal,
+      lucideRotateCw,
     }),
   ],
   templateUrl: './runner-jobs-modal.component.html',
@@ -106,6 +108,14 @@ export class RunnerJobsModalComponent implements OnInit, OnDestroy, OnChanges {
  
   stopJob(jobId: string): void {
     this.jobStore.stop(jobId);
+  }
+
+  restartJob(jobId: string): void {
+    const newId = this.jobStore.restart(jobId);
+    if (newId) {
+      this.selectedJobId = newId;
+      this.scrollSelectedToBottom();
+    }
   }
  
   removeJob(jobId: string): void {

--- a/src/app/domains/scripts/state/runner-job.store.ts
+++ b/src/app/domains/scripts/state/runner-job.store.ts
@@ -59,26 +59,30 @@ export class RunnerJobStore {
  
     this.sessionStore.broadcastTerminalEvent({ type: 'command', content: command });
  
-    this.ws
-      .executeCommandStreaming(
-        command,
-        (data: string) => {
-          outputBuffer += data;
- 
-          if (outputLineIndex === -1) {
-            outputLineIndex = this.getJobOutputLength(jobId);
-            this.appendJobLine(jobId, toSafeHtml(this.sanitizer, ''));
-          }
- 
-          this.sessionStore.broadcastTerminalEvent({ type: 'output', content: data });
-          renderScheduler.schedule();
-        },
-        (data: string) => {
-          this.sessionStore.broadcastTerminalEvent({ type: 'error', content: data });
-          this.appendJobError(jobId, data);
-        },
-      )
-      .then((result) => {
+    const { promise, messageId } = this.ws.executeCommandStreaming(
+      command,
+      (data: string) => {
+        outputBuffer += data;
+
+        if (outputLineIndex === -1) {
+          outputLineIndex = this.getJobOutputLength(jobId);
+          this.appendJobLine(jobId, toSafeHtml(this.sanitizer, ''));
+        }
+
+        this.sessionStore.broadcastTerminalEvent({ type: 'output', content: data });
+        renderScheduler.schedule();
+      },
+      (data: string) => {
+        this.sessionStore.broadcastTerminalEvent({ type: 'error', content: data });
+        this.appendJobError(jobId, data);
+      },
+    );
+
+    this.jobsSubject.next(
+      this.jobsSubject.value.map((j) => (j.id === jobId ? { ...j, wsMessageId: messageId } : j)),
+    );
+
+    promise.then((result) => {
         if (outputLineIndex >= 0) {
           this.updateJobOutputLine(jobId, outputLineIndex, outputBuffer);
         }
@@ -126,18 +130,46 @@ export class RunnerJobStore {
     return jobId;
   }
  
+  createManualJob(jobId: string, command: string, label: string, wsMessageId: string): void {
+    const ansiConverter = createAnsiConverter();
+    this.ansiConverters.set(jobId, ansiConverter);
+
+    const job: RunnerJob = {
+      id: jobId,
+      command,
+      label,
+      status: 'running',
+      outputLines: [],
+      startedAt: new Date(),
+      wsMessageId,
+    };
+    this.jobsSubject.next([...this.jobsSubject.value, job]);
+  }
+
   stop(jobId: string): void {
     const job = this.getJob(jobId);
- 
+
     if (!job || job.status !== 'running') {
       return;
     }
- 
+
+    if (job.wsMessageId) {
+      this.ws.killCommand(job.wsMessageId);
+    }
+
     this.updateJobStatus(jobId, 'stopped');
     this.appendJobLine(
       jobId,
       toSafeHtml(this.sanitizer, `<span class="text-yellow-500">⏹ Stopped by user</span>`),
     );
+  }
+
+  restart(jobId: string): string | undefined {
+    const job = this.getJob(jobId);
+    if (job) {
+      return this.run(job.command, job.label);
+    }
+    return undefined;
   }
  
   remove(jobId: string): void {
@@ -153,7 +185,7 @@ export class RunnerJobStore {
     return this.jobsSubject.value.find((j) => j.id === jobId);
   }
  
-  private updateJobStatus(jobId: string, status: RunnerJob['status'], exitCode?: number): void {
+  updateJobStatus(jobId: string, status: RunnerJob['status'], exitCode?: number): void {
     this.jobsSubject.next(
       this.jobsSubject.value.map((j) =>
         j.id === jobId
@@ -163,11 +195,11 @@ export class RunnerJobStore {
     );
   }
  
-  private getJobOutputLength(jobId: string): number {
+  getJobOutputLength(jobId: string): number {
     return this.getJob(jobId)?.outputLines.length ?? 0;
   }
  
-  private appendJobLine(jobId: string, line: ReturnType<typeof toSafeHtml>): void {
+  appendJobLine(jobId: string, line: ReturnType<typeof toSafeHtml>): void {
     this.jobsSubject.next(
       this.jobsSubject.value.map((j) =>
         j.id === jobId ? { ...j, outputLines: [...j.outputLines, line] } : j,
@@ -175,7 +207,7 @@ export class RunnerJobStore {
     );
   }
  
-  private updateJobOutputLine(jobId: string, lineIndex: number, buffer: string): void {
+  updateJobOutputLine(jobId: string, lineIndex: number, buffer: string): void {
     const converter = this.ansiConverters.get(jobId);
  
     if (!converter) {
@@ -201,7 +233,7 @@ export class RunnerJobStore {
     );
   }
  
-  private appendJobError(jobId: string, data: string): void {
+  appendJobError(jobId: string, data: string): void {
     const job = this.getJob(jobId);
  
     if (!job) {

--- a/src/app/domains/terminal/ui/terminal-panel/terminal.component.html
+++ b/src/app/domains/terminal/ui/terminal-panel/terminal.component.html
@@ -27,122 +27,142 @@
       </div>
     </div>
 
-    <div class="relative inline-block shrink-0">
-      <hlm-dialog>
-        <button
-          brnDialogTrigger
-          hlmBtn
-          type="button"
-          variant="outline"
-          size="sm"
-          class="h-9 px-3 gap-2 text-xs font-medium max-w-[60vw] sm:max-w-none"
-          [class.border-red-400]="!isConnected"
-          [class.text-red-500]="!isConnected"
-          [class.bg-red-50]="!isConnected"
-          (click)="$event.stopPropagation()"
-        >
-          <div
-            class="status-indicator"
-            [class.bg-green-500]="isConnected"
-            [class.bg-red-500]="!isConnected"
-          ></div>
-          <div class="min-w-0 flex items-center gap-1.5">
-            @if (isConnected) {
-              <span class="text-[11px] text-muted-foreground whitespace-nowrap">{{ 'terminal.connection.connectedTo' | translate }}</span>
-            }
-            <span class="text-xs truncate max-w-[160px] sm:max-w-[260px]">{{ isConnected ? serverUrl : ('terminal.connection.disconnected' | translate) }}</span>
-          </div>
-          <ng-icon hlm size="sm" name="lucideSettings" class="opacity-60" />
-        </button>
+    <div class="flex items-center gap-2 shrink-0">
+      <!-- Jobs button with badge -->
+      <button
+        hlmBtn
+        variant="outline"
+        size="sm"
+        class="relative h-9 px-3 gap-2 text-xs font-medium"
+        (click)="openJobsModal()"
+        (click)="$event.stopPropagation()"
+      >
+        <ng-icon hlm name="lucideActivity" size="sm" />
+        <span class="hidden sm:inline">{{ 'terminal.header.jobs' | translate }}</span>
+        @if (runningJobCount > 0) {
+          <span class="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 rounded-full bg-blue-500 text-white text-[10px] font-bold flex items-center justify-center leading-none">
+            {{ runningJobCount }}
+          </span>
+        }
+      </button>
 
-        <hlm-dialog-content *brnDialogContent="let ctx" class="sm:max-w-[520px] border border-border/60 bg-background/95 backdrop-blur-sm">
-          <hlm-dialog-header>
-            <div class="flex items-start gap-3">
-              <div class="h-10 w-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                <ng-icon hlm size="sm" name="lucideGlobe" class="text-primary" />
-              </div>
-              <div>
-                <h3 hlmDialogTitle>{{ 'terminal.connection.dialogTitle' | translate }}</h3>
-                <p hlmDialogDescription>{{ 'terminal.connection.dialogDescription' | translate }}</p>
-              </div>
+      <div class="relative inline-block shrink-0">
+        <hlm-dialog>
+          <button
+            brnDialogTrigger
+            hlmBtn
+            type="button"
+            variant="outline"
+            size="sm"
+            class="h-9 px-3 gap-2 text-xs font-medium max-w-[60vw] sm:max-w-none"
+            [class.border-red-400]="!isConnected"
+            [class.text-red-500]="!isConnected"
+            [class.bg-red-50]="!isConnected"
+            (click)="$event.stopPropagation()"
+          >
+            <div
+              class="status-indicator"
+              [class.bg-green-500]="isConnected"
+              [class.bg-red-500]="!isConnected"
+            ></div>
+            <div class="min-w-0 flex items-center gap-1.5">
+              @if (isConnected) {
+                <span class="text-[11px] text-muted-foreground whitespace-nowrap">{{ 'terminal.connection.connectedTo' | translate }}</span>
+              }
+              <span class="text-xs truncate max-w-[160px] sm:max-w-[260px]">{{ isConnected ? serverUrl : ('terminal.connection.disconnected' | translate) }}</span>
             </div>
-          </hlm-dialog-header>
+            <ng-icon hlm size="sm" name="lucideSettings" class="opacity-60" />
+          </button>
 
-          <div class="grid gap-4 py-4">
-            <div class="rounded-lg border border-border/60 bg-card/60 p-3 space-y-2">
-              <label hlmLabel for="url">{{ 'terminal.connection.urlLabel' | translate }}</label>
-              <div class="flex gap-2">
-                <input
-                  id="url"
-                  hlmInput
-                  [(ngModel)]="serverUrl"
-                  placeholder="ws://localhost:42712"
-                  class="flex-1 font-mono text-xs sm:text-sm"
-                />
-                <button
-                  hlmBtn
-                  type="button"
-                  variant="secondary"
-                  class="h-9 w-9 p-0 shrink-0 inline-flex items-center justify-center leading-none"
-                  [attr.aria-label]="'terminal.connection.ariaSave' | translate"
-                  (click)="saveServer()"
-                >
-                  <ng-icon hlm size="sm" name="lucideSave" class="align-middle" />
-                  <span class="sr-only">{{ 'terminal.connection.ariaSave' | translate }}</span>
-                </button>
-              </div>
-            </div>
-
-            @if (savedServers.length > 0) {
-              <div class="space-y-2">
-                <h4 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                  {{ 'terminal.connection.savedServers' | translate }}
-                </h4>
-                <div class="grid gap-2 max-h-52 overflow-y-auto pr-1">
-                  @for (server of savedServers; track server) {
-                    <div
-                      class="flex items-center justify-between p-2.5 rounded-md border border-border/60 hover:border-primary/30 hover:bg-muted/50 transition-all cursor-pointer group"
-                      (click)="selectServer(server)"
-                      (keydown.enter)="selectServer(server)"
-                      (keydown.space)="selectServer(server); $event.preventDefault()"
-                      tabindex="0"
-                      role="button"
-                    >
-                      <div class="flex items-center gap-2 overflow-hidden min-w-0">
-                        <ng-icon hlm size="sm" name="lucideServer" class="text-muted-foreground flex-shrink-0" />
-                        <span class="text-xs sm:text-sm truncate font-mono">{{ server }}</span>
-                      </div>
-                      <button
-                        hlmBtn
-                        type="button"
-                        size="icon"
-                        variant="ghost"
-                        class="h-7 w-7 opacity-70 sm:opacity-0 sm:group-hover:opacity-100"
-                        [attr.aria-label]="'terminal.connection.ariaRemove' | translate"
-                        (click)="removeServer(server, $event)"
-                      >
-                        <ng-icon hlm size="sm" name="lucideTrash2" class="text-destructive" />
-                        <span class="sr-only">{{ 'terminal.connection.ariaRemove' | translate }}</span>
-                      </button>
-                    </div>
-                  }
+          <hlm-dialog-content *brnDialogContent="let ctx" class="sm:max-w-[520px] border border-border/60 bg-background/95 backdrop-blur-sm">
+            <hlm-dialog-header>
+              <div class="flex items-start gap-3">
+                <div class="h-10 w-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                  <ng-icon hlm size="sm" name="lucideGlobe" class="text-primary" />
+                </div>
+                <div>
+                  <h3 hlmDialogTitle>{{ 'terminal.connection.dialogTitle' | translate }}</h3>
+                  <p hlmDialogDescription>{{ 'terminal.connection.dialogDescription' | translate }}</p>
                 </div>
               </div>
-            }
-          </div>
+            </hlm-dialog-header>
 
-          <hlm-dialog-footer>
-            <button hlmBtn type="button" variant="outline" brnDialogClose class="h-9 px-3 gap-2 inline-flex items-center justify-center leading-none">
-              <ng-icon hlm size="sm" name="lucideX" class="align-middle flex-shrink-0" />
-              <span class="leading-none">{{ 'terminal.connection.cancel' | translate }}</span>
-            </button>
-            <button hlmBtn type="button" (click)="reconnect(); ctx.close()" class="h-9 px-3 gap-2 inline-flex items-center justify-center leading-none">
-              <ng-icon hlm size="sm" name="lucideZap" class="align-middle flex-shrink-0" />
-              <span class="leading-none">{{ 'terminal.connection.connect' | translate }}</span>
-            </button>
-          </hlm-dialog-footer>
-        </hlm-dialog-content>
-      </hlm-dialog>
+            <div class="grid gap-4 py-4">
+              <div class="rounded-lg border border-border/60 bg-card/60 p-3 space-y-2">
+                <label hlmLabel for="url">{{ 'terminal.connection.urlLabel' | translate }}</label>
+                <div class="flex gap-2">
+                  <input
+                    id="url"
+                    hlmInput
+                    [(ngModel)]="serverUrl"
+                    placeholder="ws://localhost:42712"
+                    class="flex-1 font-mono text-xs sm:text-sm"
+                  />
+                  <button
+                    hlmBtn
+                    type="button"
+                    variant="secondary"
+                    class="h-9 w-9 p-0 shrink-0 inline-flex items-center justify-center leading-none"
+                    [attr.aria-label]="'terminal.connection.ariaSave' | translate"
+                    (click)="saveServer()"
+                  >
+                    <ng-icon hlm size="sm" name="lucideSave" class="align-middle" />
+                    <span class="sr-only">{{ 'terminal.connection.ariaSave' | translate }}</span>
+                  </button>
+                </div>
+              </div>
+
+              @if (savedServers.length > 0) {
+                <div class="space-y-2">
+                  <h4 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    {{ 'terminal.connection.savedServers' | translate }}
+                  </h4>
+                  <div class="grid gap-2 max-h-52 overflow-y-auto pr-1">
+                    @for (server of savedServers; track server) {
+                      <div
+                        class="flex items-center justify-between p-2.5 rounded-md border border-border/60 hover:border-primary/30 hover:bg-muted/50 transition-all cursor-pointer group"
+                        (click)="selectServer(server)"
+                        (keydown.enter)="selectServer(server)"
+                        (keydown.space)="selectServer(server); $event.preventDefault()"
+                        tabindex="0"
+                        role="button"
+                      >
+                        <div class="flex items-center gap-2 overflow-hidden min-w-0">
+                          <ng-icon hlm size="sm" name="lucideServer" class="text-muted-foreground flex-shrink-0" />
+                          <span class="text-xs sm:text-sm truncate font-mono">{{ server }}</span>
+                        </div>
+                        <button
+                          hlmBtn
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          class="h-7 w-7 opacity-70 sm:opacity-0 sm:group-hover:opacity-100"
+                          [attr.aria-label]="'terminal.connection.ariaRemove' | translate"
+                          (click)="removeServer(server, $event)"
+                        >
+                          <ng-icon hlm size="sm" name="lucideTrash2" class="text-destructive" />
+                          <span class="sr-only">{{ 'terminal.connection.ariaRemove' | translate }}</span>
+                        </button>
+                      </div>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+
+            <hlm-dialog-footer>
+              <button hlmBtn type="button" variant="outline" brnDialogClose class="h-9 px-3 gap-2 inline-flex items-center justify-center leading-none">
+                <ng-icon hlm size="sm" name="lucideX" class="align-middle flex-shrink-0" />
+                <span class="leading-none">{{ 'terminal.connection.cancel' | translate }}</span>
+              </button>
+              <button hlmBtn type="button" (click)="reconnect(); ctx.close()" class="h-9 px-3 gap-2 inline-flex items-center justify-center leading-none">
+                <ng-icon hlm size="sm" name="lucideZap" class="align-middle flex-shrink-0" />
+                <span class="leading-none">{{ 'terminal.connection.connect' | translate }}</span>
+              </button>
+            </hlm-dialog-footer>
+          </hlm-dialog-content>
+        </hlm-dialog>
+      </div>
     </div>
   </div>
 
@@ -184,13 +204,11 @@
       #selectionTrigger
       type="button"
       [brnMenuTriggerFor]="selectionMenu"
-      class="fixed pointer-events-none w-1 h-1 opacity-0"
+      class="fixed pointer-events-none w-0 h-0 opacity-0"
       [style.left.px]="selectionMenuPosition.x"
       [style.top.px]="selectionMenuPosition.y"
       [attr.aria-label]="'terminal.ariaOpenSelection' | translate"
-    >
-      <span class="sr-only">{{ 'terminal.ariaOpenSelection' | translate }}</span>
-    </button>
+    ></button>
 
     @if (autocompleteSuggestions.length > 0) {
       <div class="autocomplete-suggestions mb-2">
@@ -203,12 +221,13 @@
     }
 
     <div class="input-line flex items-center mt-2">
-      <span class="prompt text-primary font-bold mr-2">{{ prompt }}</span>
+      <span class="prompt text-primary font-bold mr-2">{{ activeMessageId ? (activeCommandName + ' >') : prompt }}</span>
       <input
         #commandInput
         class="flex-1 bg-transparent border-none outline-none text-foreground font-inherit p-0 m-0"
         type="text"
         [(ngModel)]="currentCommand"
+        (keydown)="onKeyDown($event)"
         (keydown.enter)="executeCommand()"
         (keydown.arrowup)="navigateHistory('up', $event)"
         (keydown.arrowdown)="navigateHistory('down', $event)"
@@ -269,6 +288,10 @@
     </hlm-menu-group>
   </hlm-menu>
 </ng-template>
+
+<app-runner-jobs-modal
+  [(visible)]="showJobsModal"
+/>
 
 <ng-template #writeupsSubMenu>
   <hlm-sub-menu class="w-64 max-h-80 overflow-y-auto shadow-2xl border-border/50 bg-background/95 backdrop-blur-sm animate-in slide-in-from-right-1 rounded-xl">

--- a/src/app/domains/terminal/ui/terminal-panel/terminal.component.ts
+++ b/src/app/domains/terminal/ui/terminal-panel/terminal.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  HostListener,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -41,6 +42,10 @@ import { BrnDialogClose, BrnDialogContent, BrnDialogTrigger } from '@spartan-ng/
 import { BrnMenuTrigger } from '@spartan-ng/brain/menu';
 
 import { WebSocketService } from '../../../../infrastructure/transport/websocket/websocket.service';
+import { CommandSignalKind } from '../../../../infrastructure/transport/websocket/websocket-command.protocol';
+import { RunnerJobStore } from '../../../scripts/state/runner-job.store';
+import { generateUUID } from '../../../../infrastructure/transport/websocket/websocket-uuid.utils';
+import { toSafeHtml } from '../../../command-runner/utils/command-runner-render.utils';
 import type { FilePrefix } from '../../models/file-prefix.type';
 import type { LsEntry } from '../../models/ls-entry.model';
 import type { TerminalLine } from '../../models/terminal-line.model';
@@ -60,6 +65,8 @@ import type { WriteUpMetadata } from '../../../writeups/models/writeup.model';
 import { TranslatePipe } from '../../../../shell/menubar/translate.pipe';
 import { I18nService } from '../../../../shell/menubar/i18n.service';
 import { DEFAULT_CHAT_NAME } from '../../../../shared/constants/default-item-names.constants';
+import { RunnerJobsModalComponent } from '../../../../domains/command-runner/ui/runner-jobs-modal.component';
+import { lucideActivity } from '@ng-icons/lucide';
 
 interface MenuTriggerLike {
   open(): void;
@@ -92,9 +99,11 @@ interface BrnMenuTriggerInternals {
     BrnDialogContent,
     BrnDialogClose,
     TranslatePipe,
+    RunnerJobsModalComponent,
   ],
   providers: [
     provideIcons({
+      lucideActivity,
       lucideClock3,
       lucideServer,
       lucidePlus,
@@ -122,6 +131,7 @@ export class TerminalComponent implements OnInit, OnDestroy {
   private readonly sessionStore = inject(SessionStore);
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly runnerJobStore = inject(RunnerJobStore);
   readonly i18n = inject(I18nService);
 
   @ViewChild('scrollContainer') private scrollContainer!: ElementRef;
@@ -142,6 +152,10 @@ export class TerminalComponent implements OnInit, OnDestroy {
   serverUrl = '';
   savedServers: string[] = ['ws://localhost:42712', 'wss://echo.websocket.org'];
   isSessionLoading = false;
+  activeMessageId: string | null = null;
+  activeCommandName: string | null = null;
+  runningJobCount = 0;
+  showJobsModal = false;
 
   selectedText = '';
   selectionMenuPosition = { x: 0, y: 0 };
@@ -212,6 +226,13 @@ export class TerminalComponent implements OnInit, OnDestroy {
       }),
     );
 
+    this.subscriptions.add(
+      this.runnerJobStore.runningCount$.subscribe((count) => {
+        this.runningJobCount = count;
+        this.cdr.detectChanges();
+      }),
+    );
+
     void this.writeUpStore.refreshAllWriteUps(0, 6, false);
     this.connect();
   }
@@ -227,7 +248,15 @@ export class TerminalComponent implements OnInit, OnDestroy {
   async executeCommand(): Promise<void> {
     const cmd = this.currentCommand.trim();
 
-    if (!cmd) {
+    if (!cmd && !this.activeMessageId) {
+      return;
+    }
+
+    if (this.activeMessageId) {
+      this.wsService.sendInput(this.activeMessageId, this.currentCommand + '\n');
+      this.addLine('output', this.currentCommand);
+      this.currentCommand = '';
+      this.scrollToBottom();
       return;
     }
 
@@ -299,32 +328,49 @@ export class TerminalComponent implements OnInit, OnDestroy {
       }
 
       lastRenderTime = now;
+      lastRenderTime = now;
       this.renderOutputBuffer(outputLineIndex, outputBuffer);
     };
 
-    this.wsService
-      .executeCommandStreaming(
-        cmd,
-        (data: string) => {
-          outputBuffer += data;
+    const jobId = generateUUID();
+    let jobOutputLineIndex = -1;
 
-          if (outputLineIndex === -1) {
-            outputLineIndex = this.lines.length;
-            this.lines.push({
-              id: this.nextLineId('live-output'),
-              type: 'output',
-              content: '',
-              timestamp: new Date(),
-            });
-          }
+    const { promise, messageId } = this.wsService.executeCommandStreaming(
+      cmd,
+      (data: string) => {
+        outputBuffer += data;
 
-          scheduleRender();
-        },
-        (data: string) => {
-          errorBuffer += data;
-          this.appendToLastError(data);
-        },
-      )
+        if (outputLineIndex === -1) {
+          outputLineIndex = this.lines.length;
+          this.lines.push({
+            id: this.nextLineId('live-output'),
+            type: 'output',
+            content: '',
+            timestamp: new Date(),
+          });
+        }
+
+        scheduleRender();
+
+        // Update Job Store
+        if (jobOutputLineIndex === -1) {
+          jobOutputLineIndex = this.runnerJobStore.getJobOutputLength(jobId);
+          this.runnerJobStore.appendJobLine(jobId, toSafeHtml(this.sanitizer, ''));
+        }
+        this.runnerJobStore.updateJobOutputLine(jobId, jobOutputLineIndex, outputBuffer);
+      },
+      (data: string) => {
+        errorBuffer += data;
+        this.appendToLastError(data);
+        this.runnerJobStore.appendJobError(jobId, data);
+      },
+    );
+
+    this.activeMessageId = messageId;
+    this.activeCommandName = cmd.split(' ')[0];
+    this.runnerJobStore.createManualJob(jobId, cmd, cmd, messageId);
+
+    promise
       .then((result) => {
         if (outputLineIndex >= 0) {
           this.renderOutputBuffer(outputLineIndex, outputBuffer);
@@ -339,7 +385,7 @@ export class TerminalComponent implements OnInit, OnDestroy {
         }
 
         if (result.exitCode !== 0 && !errorBuffer) {
-          this.addLine('error', `Program exited with code ${result.exitCode}`);
+          this.addLine('error', this.i18n.translate('terminal.log.programExited', { code: result.exitCode }));
         }
 
         if (looksLikeDirectoryChange(cmd)) {
@@ -347,14 +393,26 @@ export class TerminalComponent implements OnInit, OnDestroy {
         }
 
         this.scrollToBottom();
+        this.runnerJobStore.updateJobStatus(jobId, 'completed', result.exitCode);
       })
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
-        this.addLine('error', `Execution failed: ${message}`);
+        this.addLine('error', this.i18n.translate('terminal.log.executionFailed', { message }));
+        this.runnerJobStore.updateJobStatus(jobId, 'error');
+      })
+      .finally(() => {
+        if (this.activeMessageId === messageId) {
+          this.activeMessageId = null;
+          this.activeCommandName = null;
+        }
       });
   }
 
   onTabAutocomplete(event: Event): void {
+    if (this.activeMessageId) {
+      return;
+    }
+
     const keyboardEvent = event as KeyboardEvent;
     keyboardEvent.preventDefault();
 
@@ -371,6 +429,10 @@ export class TerminalComponent implements OnInit, OnDestroy {
   }
 
   onInput(): void {
+    if (this.activeMessageId) {
+      this.clearAutocompleteSuggestions();
+      return;
+    }
     this.autocompleteSuggestions = this.autocomplete.getSuggestions(this.currentCommand);
     this.cdr.detectChanges();
   }
@@ -395,6 +457,45 @@ export class TerminalComponent implements OnInit, OnDestroy {
     if (this.autocompleteSuggestions.length > 0) {
       this.autocompleteSuggestions = [];
       this.cdr.detectChanges();
+    }
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    if (event.ctrlKey && event.key === 'c') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (this.activeMessageId) {
+        this.wsService.sendSignal(this.activeMessageId, CommandSignalKind.Interrupt);
+      } else if (this.currentCommand) {
+        this.currentCommand = '';
+        this.addLine('command', `${this.prompt} ^C`);
+        this.scrollToBottom();
+      }
+      return;
+    }
+
+    if (event.ctrlKey && event.key === 'd') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (this.activeMessageId) {
+        this.wsService.sendSignal(this.activeMessageId, CommandSignalKind.Eof);
+      } else {
+        toast.info(this.i18n.translate('terminal.signals.eofOnlyOnJobs'));
+      }
+      return;
+    }
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  onGlobalKeyDown(event: KeyboardEvent): void {
+    if (event.ctrlKey && (event.key === 'd' || event.key === 'D')) {
+      const activeEl = document.activeElement;
+      const isInsideTerminal = this.commandInput?.nativeElement?.contains(activeEl) || 
+                               (activeEl instanceof HTMLElement && activeEl.closest('.terminal-container'));
+      
+      if (isInsideTerminal) {
+        this.onKeyDown(event);
+      }
     }
   }
 
@@ -641,7 +742,7 @@ export class TerminalComponent implements OnInit, OnDestroy {
       })
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : 'Unknown error';
-        this.addLine('error', `Connection failed: ${message}`);
+        this.addLine('error', this.i18n.translate('terminal.log.connectionFailed', { message }));
       });
   }
 
@@ -652,7 +753,7 @@ export class TerminalComponent implements OnInit, OnDestroy {
         () => { /* Ignore */ },
         () => { /* Ignore */ },
       )
-      .then((result) => {
+      .promise.then((result) => {
         if (result.workingDirectory) {
           this.updatePwd(result.workingDirectory);
         }
@@ -693,7 +794,7 @@ export class TerminalComponent implements OnInit, OnDestroy {
         (data) => { output += data; },
         () => { /* Ignore */ },
       )
-      .then(() => {
+      .promise.then(() => {
         if (output) {
           this.updateLsCache(output);
         }
@@ -992,5 +1093,9 @@ export class TerminalComponent implements OnInit, OnDestroy {
       });
       return null;
     }
+  }
+
+  openJobsModal(): void {
+    this.showJobsModal = true;
   }
 }

--- a/src/app/infrastructure/transport/websocket/websocket-command.protocol.ts
+++ b/src/app/infrastructure/transport/websocket/websocket-command.protocol.ts
@@ -2,6 +2,11 @@
 import { MessageType } from './websocket-message-type.enum';
 import { bytesToUuid, uuidToBytes } from './websocket-uuid.utils';
 import { BinaryReader, toUint8Array } from './websocket-protocol.utils';
+ 
+export enum CommandSignalKind {
+  Interrupt = 0,
+  Eof = 1,
+}
 
 export interface CommandResponse {
   type: MessageType.CompleteResponse;
@@ -56,6 +61,35 @@ export function serializePasswordProvide(messageId: string, password: string): U
   buffer.set(uuidToBytes(messageId), 1);
   view.setInt32(17, passwordBytes.length, true);
   buffer.set(passwordBytes, 21);
+  return buffer;
+}
+
+export function serializeCommandSignal(messageId: string, kind: CommandSignalKind): Uint8Array {
+  const buffer = new Uint8Array(1 + 16 + 1);
+  const view = new DataView(buffer.buffer);
+  view.setUint8(0, MessageType.CommandSignal);
+  buffer.set(uuidToBytes(messageId), 1);
+  view.setUint8(17, kind);
+  return buffer;
+}
+
+export function serializeCommandKill(messageId: string): Uint8Array {
+  const buffer = new Uint8Array(1 + 16);
+  const view = new DataView(buffer.buffer);
+  view.setUint8(0, MessageType.CommandKill);
+  buffer.set(uuidToBytes(messageId), 1);
+  return buffer;
+}
+
+export function serializeCommandInput(messageId: string, input: string): Uint8Array {
+  const encoder = new TextEncoder();
+  const inputBytes = encoder.encode(input);
+  const buffer = new Uint8Array(1 + 16 + 4 + inputBytes.length);
+  const view = new DataView(buffer.buffer);
+  view.setUint8(0, MessageType.CommandInput);
+  buffer.set(uuidToBytes(messageId), 1);
+  view.setUint32(17, inputBytes.length, true);
+  buffer.set(inputBytes, 21);
   return buffer;
 }
 

--- a/src/app/infrastructure/transport/websocket/websocket-message-type.enum.ts
+++ b/src/app/infrastructure/transport/websocket/websocket-message-type.enum.ts
@@ -8,6 +8,8 @@ export enum MessageType {
   CommandExecute = 6,
   PasswordRequest = 7,
   PasswordProvide = 8,
+  CommandSignal = 9,
+  CommandInput = 150,
 
   SessionCreate = 10,
   SessionSetActive = 11,

--- a/src/app/infrastructure/transport/websocket/websocket.service.ts
+++ b/src/app/infrastructure/transport/websocket/websocket.service.ts
@@ -3,10 +3,14 @@ import { BehaviorSubject } from 'rxjs';
 import { SudoPasswordModalStore } from '../../../shell/sudo-password-modal/sudo-password-modal.store';
 import {
   CommandResponse,
+  CommandSignalKind,
   deserializeMessage,
   PasswordRequest,
   serializeCommand,
+  serializeCommandKill,
+  serializeCommandSignal,
   serializePasswordProvide,
+  serializeCommandInput,
   StreamChunk,
   StreamEnd,
   StreamMessage,
@@ -162,15 +166,18 @@ export class WebSocketService {
     command: string,
     onOutput: (data: string) => void,
     onError: (data: string) => void,
-  ): Promise<StreamingResult> {
+  ): { promise: Promise<StreamingResult>; messageId: string } {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return Promise.reject(new Error('WebSocket not connected'));
+      return {
+        promise: Promise.reject(new Error('WebSocket not connected')),
+        messageId: '',
+      };
     }
 
     const messageId = generateUUID();
     const payload = serializeCommand(command, messageId);
 
-    return new Promise<StreamingResult>((resolve, reject) => {
+    const promise = new Promise<StreamingResult>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         this.streamingCallbacks.delete(messageId);
         this.pending.delete(messageId);
@@ -218,6 +225,35 @@ export class WebSocketService {
         reject(error);
       }
     });
+
+    return { promise, messageId };
+  }
+
+  sendSignal(messageId: string, kind: CommandSignalKind): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const payload = serializeCommandSignal(messageId, kind);
+    this.ws.send(payload);
+  }
+
+  sendInput(messageId: string, input: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const payload = serializeCommandInput(messageId, input);
+    this.ws.send(payload);
+  }
+
+  killCommand(messageId: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const payload = serializeCommandKill(messageId);
+    this.ws.send(payload);
   }
 
   private connectWithRetry(): void {

--- a/src/app/shell/menubar/i18n.service.ts
+++ b/src/app/shell/menubar/i18n.service.ts
@@ -393,6 +393,7 @@ const translations: Record<SupportedLang, Record<string, string>> = {
     'runner.help.close': 'Close',
     'runner.run.stop': 'Stop',
     'runner.run.running': 'Running...',
+    'runner.run.restart': 'Restart',
     'runner.run.run': 'Run',
     'runner.output.title': 'Terminal Output',
     'runner.output.clear': 'Clear',
@@ -424,6 +425,16 @@ const translations: Record<SupportedLang, Record<string, string>> = {
     'runner.jobs.background': 'Commands run in the background.',
     'runner.jobs.open': 'Open jobs',
     'runner.jobs.description': 'to view their progress.',
+    //
+    'terminal.header.jobs': 'Jobs',
+    'terminal.signals.eofOnlyOnJobs': 'Ctrl+D is only available for active jobs.',
+    'terminal.log.connectionFailed': 'Connection failed: {message}',
+    'terminal.log.programExited': 'Program exited with code {code}',
+    'terminal.log.executionFailed': 'Execution failed: {message}',
+    'runner.status.running': 'Running',
+    'runner.status.completed': 'Completed',
+    'runner.status.stopped': 'Stopped',
+    'runner.status.error': 'Error',
   },
   fr: {
     //menubar :
@@ -710,6 +721,7 @@ const translations: Record<SupportedLang, Record<string, string>> = {
     'runner.help.close': 'Fermer',
     'runner.run.stop': 'Arrêter',
     'runner.run.running': 'En cours...',
+    'runner.run.restart': 'Relancer',
     'runner.run.run': 'Lancer',
     'runner.output.title': 'Sortie terminal',
     'runner.output.clear': 'Effacer',
@@ -796,6 +808,17 @@ const translations: Record<SupportedLang, Record<string, string>> = {
     'projects.dialog.table.date': 'Date',
     'projects.dialog.table.folders': 'Dossiers',
     'projects.dialog.table.lastChanged': 'Derniere modification',
+    //
+    'terminal.header.jobs': 'Tâches',
+    'terminal.signals.eofOnlyOnJobs': 'Ctrl+D est uniquement disponible pour les tâches actives.',
+    'terminal.log.connectionFailed': 'Échec de connexion : {message}',
+    'terminal.log.programExited': 'Le programme s\'est terminé avec le code {code}',
+    'terminal.log.executionFailed': 'Échec de l\'exécution : {message}',
+    'runner.status.running': 'En cours',
+    'runner.status.completed': 'Terminé',
+    'runner.status.stopped': 'Arrêté',
+    'runner.status.error': 'Erreur',
+
     'projects.dialog.import.title': 'Importer un projet',
     'projects.dialog.import.description': 'Importer des projets depuis le dossier d export du serveur.',
     'projects.dialog.import.availableExports': 'Exports disponibles',
@@ -1106,6 +1129,7 @@ const translations: Record<SupportedLang, Record<string, string>> = {
     'runner.help.close': 'Cerrar',
     'runner.run.stop': 'Detener',
     'runner.run.running': 'Ejecutando...',
+    'runner.run.restart': 'Reiniciar',
     'runner.run.run': 'Ejecutar',
     'runner.output.title': 'Salida del terminal',
     'runner.output.clear': 'Limpiar',
@@ -1138,6 +1162,15 @@ const translations: Record<SupportedLang, Record<string, string>> = {
     'runner.jobs.open': 'Abrir tareas',
     'runner.jobs.description': 'para ver su progreso.',
     //
+    'terminal.header.jobs': 'Tareas',
+    'terminal.signals.eofOnlyOnJobs': 'Ctrl+D solo está disponible para tareas activas.',
+    'terminal.log.connectionFailed': 'Error de conexión: {message}',
+    'terminal.log.programExited': 'El programa terminó con el código {code}',
+    'terminal.log.executionFailed': 'Error de ejecución: {message}',
+    'runner.status.running': 'En curso',
+    'runner.status.completed': 'Completado',
+    'runner.status.stopped': 'Detenido',
+    'runner.status.error': 'Error',
     'sidebar.folder.renameAria': 'Renombrar carpeta',
     'sidebar.folder.deleteAria': 'Eliminar carpeta',
     'sidebar.project.export': 'Exportar proyecto',
@@ -1238,7 +1271,13 @@ export class I18nService {
     document.documentElement.lang = lang;
   }
 
-  translate(key: string): string {
-    return translations[this.currentLang()][key] ?? translations['en'][key] ?? key;
+  translate(key: string, params: Record<string, string | number> = {}): string {
+    let text = translations[this.currentLang()][key] ?? translations['en'][key] ?? key;
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        text = text.replace(new RegExp(`{${k}}`, 'g'), String(v));
+      }
+    }
+    return text;
   }
 }

--- a/src/app/shell/menubar/translate.pipe.ts
+++ b/src/app/shell/menubar/translate.pipe.ts
@@ -18,7 +18,7 @@ export class TranslatePipe implements PipeTransform {
     });
   }
 
-  transform(key: string): string {
-    return this.i18n.translate(key);
+  transform(key: string, params: Record<string, string | number> = {}): string {
+    return this.i18n.translate(key, params);
   }
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the command runner and terminal UI, focusing on better job management, enhanced user experience, and codebase maintainability. The most notable changes include adding a restart functionality for jobs, surfacing job status and controls in the terminal UI, and refactoring the job store for greater flexibility and testability.

**Command runner and job management enhancements:**

* Added a "Restart" button for completed jobs in the jobs modal, allowing users to quickly rerun previous commands. (`runner-jobs-modal.component.html`, `runner-jobs-modal.component.ts`, `runner-job.store.ts`) [[1]](diffhunk://#diff-f5f649e86b3fe19ff2ec3da271834026009ad3139407becb3f63ecff0e6eb36bR141-R146) [[2]](diffhunk://#diff-139ec21f5b22de7e1d1550cc75712f6d18fa413b181869fde9a0cffda81591ecR113-R120) [[3]](diffhunk://#diff-149537e9dae8e401bccd675b9a7c950787f1f6fdac7a0c52a91c57273a6e3ec0R133-R174)
* The `RunnerJobStore` now exposes methods like `restart`, `createManualJob`, and makes previously private methods public to facilitate job management and extensibility. (`runner-job.store.ts`) [[1]](diffhunk://#diff-149537e9dae8e401bccd675b9a7c950787f1f6fdac7a0c52a91c57273a6e3ec0R133-R174) [[2]](diffhunk://#diff-149537e9dae8e401bccd675b9a7c950787f1f6fdac7a0c52a91c57273a6e3ec0L156-R188) [[3]](diffhunk://#diff-149537e9dae8e401bccd675b9a7c950787f1f6fdac7a0c52a91c57273a6e3ec0L166-R210) [[4]](diffhunk://#diff-149537e9dae8e401bccd675b9a7c950787f1f6fdac7a0c52a91c57273a6e3ec0L204-R236)
* The `RunnerJob` model includes a new optional `wsMessageId` property to track the WebSocket message associated with each job, enabling more precise job control (e.g., stopping jobs). (`runner-job.model.ts`, `runner-job.store.ts`) [[1]](diffhunk://#diff-870a0518d5f7d5a1ed2f51f7be06975b3f3ef72703b92fb71cbd0f62a10bce16R14) [[2]](diffhunk://#diff-149537e9dae8e401bccd675b9a7c950787f1f6fdac7a0c52a91c57273a6e3ec0L80-R85)

**Terminal UI improvements:**

* Introduced a jobs button in the terminal header displaying the number of running jobs and opening the jobs modal, making job management more accessible from the terminal. (`terminal.component.html`, `terminal.component.ts`) [[1]](diffhunk://#diff-977e4378ac121525427c90b6a7c32ed76c3b8048b20e9c89fe33677ecb09e082R30-R48) [[2]](diffhunk://#diff-977e4378ac121525427c90b6a7c32ed76c3b8048b20e9c89fe33677ecb09e082R292-R295) [[3]](diffhunk://#diff-20c9afd184faad65824baac02d901ef140c697a12f98d2df8091636040740510R155-R158) [[4]](diffhunk://#diff-20c9afd184faad65824baac02d901ef140c697a12f98d2df8091636040740510R229-R235)
* The terminal prompt dynamically reflects the active command if a job is running, providing clearer context to the user. (`terminal.component.html`, `terminal.component.ts`) [[1]](diffhunk://#diff-977e4378ac121525427c90b6a7c32ed76c3b8048b20e9c89fe33677ecb09e082L206-R230) [[2]](diffhunk://#diff-20c9afd184faad65824baac02d901ef140c697a12f98d2df8091636040740510R155-R158)

**UI/UX and code consistency:**

* Improved the jobs modal header layout, showing job labels, status icons, start time, duration, and exit codes in a more organized and visually appealing way. (`runner-jobs-modal.component.html`)
* Updated various UI elements for consistency and better accessibility, such as adjusting button gaps and icon usage. (`runner-jobs-modal.component.html`, `runner-jobs-modal.component.ts`) [[1]](diffhunk://#diff-f5f649e86b3fe19ff2ec3da271834026009ad3139407becb3f63ecff0e6eb36bL103-R129) [[2]](diffhunk://#diff-139ec21f5b22de7e1d1550cc75712f6d18fa413b181869fde9a0cffda81591ecR29) [[3]](diffhunk://#diff-139ec21f5b22de7e1d1550cc75712f6d18fa413b181869fde9a0cffda81591ecR51)

These changes collectively make job management more robust and user-friendly, while also laying the groundwork for further enhancements in command execution and terminal interaction.